### PR TITLE
MIDI Constant Defines - Firmware & Config Tool

### DIFF
--- a/warbl2_firmware/Battery_management.ino
+++ b/warbl2_firmware/Battery_management.ino
@@ -65,8 +65,8 @@ void manageBattery(bool send) {
         if (prevTempChargingStatus != tempChargingStatus) {
             statusChanged = 1;
             if (communicationMode) {  // Send the status to the Config Tool if it has changed.
-                sendMIDI(CONTROL_CHANGE, 7, 106, 71);
-                sendMIDI(CONTROL_CHANGE, 7, 119, tempChargingStatus);
+                sendMIDI(MIDI_SEND_BATTERY_CHARGE_STATUS);
+                sendMIDI(MIDI_CC_119_MSG, tempChargingStatus);
             }
             prevTempChargingStatus = tempChargingStatus;
         }
@@ -96,8 +96,8 @@ void manageBattery(bool send) {
 
             prevChargingStatus = chargingStatus;
 
-            sendMIDI(CONTROL_CHANGE, 7, 106, 71);
-            sendMIDI(CONTROL_CHANGE, 7, 119, chargingStatus);  // Send charging status again in case a fault was detected.
+            sendMIDI(MIDI_SEND_BATTERY_CHARGE_STATUS);
+            sendMIDI(MIDI_CC_119_MSG, chargingStatus);  // Send charging status again in case a fault was detected.
         }
     }
 
@@ -147,14 +147,14 @@ void manageBattery(bool send) {
     static byte cycles = 40;  // 40 cycles is 30 seconds.
     if (cycles == 40 || send) {
         if (communicationMode) {
-            sendMIDI(CONTROL_CHANGE, 7, 106, 70);
-            sendMIDI(CONTROL_CHANGE, 7, 119, (((smoothed_voltage + 0.005) * 100) - 50));  // Convert to 0-127 for sending to Config Tool as 7 bits (possible range of 0.5 - 1.77 V in this format).
+            sendMIDI(MIDI_SEND_BATTERY_VOLTAGE);
+            sendMIDI(MIDI_CC_119_MSG, (((smoothed_voltage + 0.005) * 100) - 50));  // Convert to 0-127 for sending to Config Tool as 7 bits (possible range of 0.5 - 1.77 V in this format).
 
-            sendMIDI(CONTROL_CHANGE, 7, 106, 71);
-            sendMIDI(CONTROL_CHANGE, 7, 119, chargingStatus);  // Send charging status.
+            sendMIDI(MIDI_SEND_BATTERY_CHARGE_STATUS);
+            sendMIDI(MIDI_CC_119_MSG, chargingStatus);  // Send charging status.
 
-            sendMIDI(CONTROL_CHANGE, 7, 106, 74);
-            sendMIDI(CONTROL_CHANGE, 7, 119, battLevel);  // Send battery level.
+            sendMIDI(MIDI_SEND_BATTERY_CHARGE_PERC);
+            sendMIDI(MIDI_CC_119_MSG, battLevel);  // Send battery level.
         }
     }
 

--- a/warbl2_firmware/Defines.h
+++ b/warbl2_firmware/Defines.h
@@ -242,6 +242,546 @@
 #define BLUE_LED 2
 
 
+/* MIDI Config Tool Constants */
+/* To be kept in sync with constants.js in Confgi Tool */
+
+//General constants
+#define MIDI_DEFAULT_MAIN_CHANNEL             1 // Default MIDI channel to send notes on
+#define MIDI_CONFIG_TOOL_CHANNEL              7 // Config Tool MIDI channel
+#define MIDI_DEFAULT_VELOCITY               127 // 
+
+//MIDI Human readable constants: see below
+
+/* Numerical constants
+ * Some cc values are reserved from Config Tool or from WARBL
+ * Bidirectional Communication: same commands both ways with same cc/value 
+*/
+#define MIDI_CC_102                         102 // from WARBL & from Config Tool.  Various values as follows:
+    #define MIDI_CC_102_VALUE_0	              0 // unused
+    // sensor calibration messages
+    #define MIDI_CC_102_VALUE_1	              1 //from Config Tool. bell sensor down
+    #define MIDI_CC_102_VALUE_2	              2	//from Config Tool. bell sensor up
+    #define MIDI_CC_102_VALUE_3	              3	//from Config Tool. R4 down
+    #define MIDI_CC_102_VALUE_4	              4	//from Config Tool. R4 up
+    #define MIDI_CC_102_VALUE_5	              5	//from Config Tool. R3 down
+    #define MIDI_CC_102_VALUE_6	              6	//from Config Tool. R3 up
+    #define MIDI_CC_102_VALUE_7	              7	//from Config Tool. R2 down
+    #define MIDI_CC_102_VALUE_8	              8	//from Config Tool. R2 up
+    #define MIDI_CC_102_VALUE_9	              9	//from Config Tool. R1 down
+    #define MIDI_CC_102_VALUE_10	         10	//from Config Tool. R1 up
+    #define MIDI_CC_102_VALUE_11	         11	//from Config Tool. L3 down
+    #define MIDI_CC_102_VALUE_12	         12	//from Config Tool. L3 up
+    #define MIDI_CC_102_VALUE_13	         13	//from Config Tool. L2 down
+    #define MIDI_CC_102_VALUE_14	         14	//from Config Tool. L2 up
+    #define MIDI_CC_102_VALUE_15	         15	//from Config Tool. L1 down
+    #define MIDI_CC_102_VALUE_16	         16	//from Config Tool. L1 up
+    #define MIDI_CC_102_VALUE_17	         17	//from Config Tool. Lthumb down
+    #define MIDI_CC_102_VALUE_18	         18	//from Config Tool. Lthumb up		
+    #define MIDI_CC_102_VALUE_19	         19	//from Config Tool. Save optical sensor calibration
+    #define MIDI_CC_102_VALUE_20	         20	//from WARBL. bell sensor max value reached
+    #define MIDI_CC_102_VALUE_21	         21	//from WARBL. R4 max value reached
+    /* MrMep: I think there's an error in the Google Doc: 22 there is unused, but these values must be continous 
+     * see Functions.ino line 1600
+    */
+    #define MIDI_CC_102_VALUE_22	         22	//from WARBL. R3 max value reached	
+    #define MIDI_CC_102_VALUE_23	         23	//from WARBL. R2 max value reached	
+    #define MIDI_CC_102_VALUE_24	         24	//from WARBL. R1 max value reached
+    #define MIDI_CC_102_VALUE_25	         25	//from WARBL. L3 max value reached
+    #define MIDI_CC_102_VALUE_26	         26	//from WARBL. L2 max value reached
+    #define MIDI_CC_102_VALUE_27	         27	//from WARBL. L1 max value reached
+    #define MIDI_CC_102_VALUE_28	         28	//from WARBL. Lthumb max value reached
+    //
+    /* 29 unused ? */
+    //Send fingering pattern selections:
+    #define MIDI_CC_102_VALUE_30	         30	// Bidirectional. indicates that the next command will be the fingering pattern for instrument 1
+    #define MIDI_CC_102_VALUE_31	         31	// Bidirectional. indicates that the next command will be the fingering pattern for instrument 2
+    #define MIDI_CC_102_VALUE_32	         32	// Bidirectional. indicates that the next command will be the fingering pattern for instrument 3
+    #define MIDI_CC_102_VALUE_33	         33	// Bidirectional. first fingering pattern is tin whistle
+    #define MIDI_CC_102_VALUE_34	         34	// Bidirectional. "" uilleann
+    #define MIDI_CC_102_VALUE_35	         35	// Bidirectional. “” GHB
+    #define MIDI_CC_102_VALUE_36	         36	// Bidirectional. “” Northumbrian
+    #define MIDI_CC_102_VALUE_37	         37	// Bidirectional. ""tin whistle/flute chromatic
+    #define MIDI_CC_102_VALUE_38	         38	// Bidirectional. ""Gaita
+    /* 39 unused ? */
+    #define MIDI_CC_102_VALUE_40	         40	// Bidirectional. NAF
+    #define MIDI_CC_102_VALUE_41	         41	// Bidirectional. Kaval
+    #define MIDI_CC_102_VALUE_42	         42	// Bidirectional. recorder
+    #define MIDI_CC_102_VALUE_43	         43	// Bidirectional. Uilleann regulators
+    #define MIDI_CC_102_VALUE_44	         44	// Bidirectional. Uilleann standard
+    #define MIDI_CC_102_VALUE_45	         45	// Bidirectional. Xiao
+    #define MIDI_CC_102_VALUE_46	         46	// Bidirectional. Sax
+    #define MIDI_CC_102_VALUE_47	         47	// Bidirectional. Gaita extended
+    /* 48-49 unused ? */
+    #define MIDI_CC_102_VALUE_50	         50	// Bidirectional. Saxbasic
+    #define MIDI_CC_102_VALUE_51	         51	// Bidirectional. EVI
+    #define MIDI_CC_102_VALUE_52	         52	// Bidirectional. Shakuhachi
+    #define MIDI_CC_102_VALUE_53	         53	// Bidirectional. Sackpipa major
+    #define MIDI_CC_102_VALUE_54	         54	// Bidirectional. Sackpipa minor
+    #define MIDI_CC_102_VALUE_55	         55	// Bidirectional. Custom
+    #define MIDI_CC_102_VALUE_56	         56	// Bidirectional. Bombarde
+    #define MIDI_CC_102_VALUE_57	         57	// Bidirectional. Baroque flute
+    #define MIDI_CC_102_VALUE_58	         58	// Bidirectional. Medieval bagpipes
+    #define MIDI_CC_102_VALUE_59	         59	// Bidirectional. Bansuri
+    //
+
+    #define MIDI_CC_102_VALUE_60	         60	// Bidirectional. current instrument (mode variable) is  0
+    #define MIDI_CC_102_VALUE_61	         61	// Bidirectional. current instrument is 1
+    #define MIDI_CC_102_VALUE_62	         62	// Bidirectional. current instrument is 2
+    /* 63-69 unused */
+    #define MIDI_CC_102_VALUE_70	         70	// Bidirectional. Settings for current instrument: Pitchbend mode 0
+    #define MIDI_CC_102_VALUE_71	         71	// Bidirectional. Settings for current instrument: Pitchbend mode 1
+    #define MIDI_CC_102_VALUE_72	         72	// Bidirectional. Settings for current instrument: Pitchbend mode 2
+    /* MrMep: this next value is missing from the Google Doc */
+    #define MIDI_CC_102_VALUE_73	         73	// Bidirectional. Settings for current instrument: Pitchbend mode 3
+    /* 74-79 unused */
+    #define MIDI_CC_102_VALUE_80	         80	// Bidirectional. Settings for current instrument: Breath mode 0
+    #define MIDI_CC_102_VALUE_81	         81	// Bidirectional. Settings for current instrument: Breath mode 1
+    #define MIDI_CC_102_VALUE_82	         82	// Bidirectional. Settings for current instrument: Breath mode 2
+    #define MIDI_CC_102_VALUE_83	         83	// Bidirectional. Settings for current instrument: Breath mode 3
+    #define MIDI_CC_102_VALUE_84	         84	// Bidirectional. Settings for current instrument: Breath mode4
+    #define MIDI_CC_102_VALUE_85	         85	// Bidirectional. default instrument is 0 - (if Config Tool sends 85 to WARBL, WARBL sets current instrument as default)
+    #define MIDI_CC_102_VALUE_86	         86	// Bidirectional. default instrument is 1
+    #define MIDI_CC_102_VALUE_87	         87	// Bidirectional. default instrument is 2
+    /* 88-89 unused */
+
+    /* Populate button configuration for current instrument:	
+	 * First indicate button combination to be populated:
+    */
+    #define MIDI_CC_102_VALUE_90	         90	// Bidirectional. Sending data for click 1 (dropdown row 0)
+    #define MIDI_CC_102_VALUE_91	         91	// Bidirectional. click 2
+    #define MIDI_CC_102_VALUE_92	         92	// Bidirectional. click 3
+    #define MIDI_CC_102_VALUE_93	         93	// Bidirectional. hold 2, click 1
+    #define MIDI_CC_102_VALUE_94	         94	// Bidirectional. hold 2, click 3
+    #define MIDI_CC_102_VALUE_95	         95	// Bidirectional. longpress 1
+    #define MIDI_CC_102_VALUE_96	         96	// Bidirectional. longpress 2
+    #define MIDI_CC_102_VALUE_97	         97	// Bidirectional. longpress 3
+    #define MIDI_CC_102_VALUE_98	         98	// unused
+    #define MIDI_CC_102_VALUE_99	         99	// unused (previously disconnect command)
+    /* Follow with data to populate indicated button combination:
+     * CC 106	values 100-127 (see below) 
+     * (was previously CC 102 100-111 but ran out of room here)
+     */
+
+    #define MIDI_CC_102_VALUE_100	        100	// Bidirectional. WARBL2 custom fingering chart 1
+    #define MIDI_CC_102_VALUE_101	        101	// Bidirectional. WARBL2 custom fingering chart 2
+    #define MIDI_CC_102_VALUE_102	        102	// Bidirectional. WARBL2 custom fingering chart 3
+    #define MIDI_CC_102_VALUE_103	        103	// Bidirectional. WARBL2 custom fingering chart 4
+    #define MIDI_CC_102_VALUE_104	        104	//from Config Tool. exit communication mode (previously 102 99)
+    /* 105-111	unused -- can be used for WARBL2 */
+    #define MIDI_CC_102_VALUE_112	        112	// Bidirectional. send midi note on/note off
+    #define MIDI_CC_102_VALUE_113	        113	// Bidirectional. Send midi CC
+    #define MIDI_CC_102_VALUE_114	        114	// Bidirectional. Send MIDI PC
+    #define MIDI_CC_102_VALUE_115	        115	// Bidirectional. Increase PC
+    #define MIDI_CC_102_VALUE_116	        116	// Bidirectional. Decrease PC
+    #define MIDI_CC_102_VALUE_117	        117	// Bidirectional. momentary off
+    #define MIDI_CC_102_VALUE_118	        118	// Bidirectional. momentary on
+    /* 119 unused */
+    #define MIDI_CC_102_VALUE_120	        120	//from WARBL. bell sensor disconnected	
+    #define MIDI_CC_102_VALUE_121	        121	//from WARBL. bell sensor connected	
+    /* 122 unused */
+    #define MIDI_CC_102_VALUE_123	        123	//from Config Tool. save as defaults for current mode
+    #define MIDI_CC_102_VALUE_124	        124	//from Config Tool. save as defaults for all instruments
+    #define MIDI_CC_102_VALUE_125	        125	//from Config Tool. restore factory settings
+    #define MIDI_CC_102_VALUE_126	        126	//from Config Tool. enter communication mode
+                                                // WARBL enters communication mode (until it is shut off or user clicks "Disconnect") and responds by sending settings for currently selected instrument.
+    #define MIDI_CC_102_VALUE_127	        127	//from Config Tool. begin autocalibration
+
+
+#define MIDI_CC_103                         103 // from WARBL & from Config Tool.  Values 0-127	- Settings for current instrument: finger-sensing distance
+
+#define MIDI_CC_104                         104 // from WARBL & from Config Tool.  Various values as follows:
+    /* 0 unused */
+
+    /* Bag/Breath advanced settings (pressureSelector array) */
+    #define MIDI_CC_104_VALUE_1 	          1	// Bidirectional. Settings for current instrument: indicates "bag threshold" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_2 	          2	// Bidirectional. Settings for current instrument: indicates "bag multiplier" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_3 	          3	// Bidirectional. Settings for current instrument: indicates "bag histeresis" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_4 	          4	// Bidirectional. unused. 
+    #define MIDI_CC_104_VALUE_5 	          5	// Bidirectional. Settings for current instrument: indicates "bag jump time" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_6 	          6	// Bidirectional. Settings for current instrument: indicates "bag drop time" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_7 	          7	// Bidirectional. Settings for current instrument: indicates "breath threshold" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_8 	          8	// Bidirectional. Settings for current instrument: indicates "breath multiplier" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_9 	          9	// Bidirectional. Settings for current instrument: indicates "breath histeresis" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_10 	         10	// Bidirectional. Settings for current instrument: indicates "breath transient filter" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_11	         11	// Bidirectional. Settings for current instrument: indicates "breath jump time" is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_12	         12	// Bidirectional. Settings for current instrument: indicates "breath  drop time" is about to be sent with CC 105.
+    //
+    /* Expression or drones variable (ED array) - see defines above */
+    #define MIDI_CC_104_VALUE_13	         13	// Bidirectional. Settings for current instrument: indicates ED[0] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_14	         14	// Bidirectional. Settings for current instrument: indicates ED[1] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_15	         15	// Bidirectional. Settings for current instrument: indicates ED[2] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_16	         16	// Bidirectional. Settings for current instrument: indicates ED[3] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_17	         17	// Bidirectional. Settings for current instrument: indicates ED[4] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_18	         18	// Bidirectional. Settings for current instrument: indicates ED[5] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_19	         19	// Bidirectional. Settings for current instrument: indicates ED[6] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_20	         20	// Bidirectional. Settings for current instrument: indicates ED[7] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_21	         21	// Bidirectional. Settings for current instrument: indicates ED[8] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_22	         22	// Bidirectional. Settings for current instrument: indicates ED[9] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_23	         23	// Bidirectional. Settings for current instrument: indicates ED[10] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_24	         24	// Bidirectional. Settings for current instrument: indicates ED[11] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_25	         25	// Bidirectional. Settings for current instrument: indicates ED[12]] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_26	         26	// Bidirectional. Settings for current instrument: indicates ED[13] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_27	         27	// Bidirectional. Settings for current instrument: indicates ED[14] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_28	         28	// Bidirectional. Settings for current instrument: indicates ED[15] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_29	         29	// Bidirectional. Settings for current instrument: indicates ED[16] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_30	         30	// Bidirectional. Settings for current instrument: indicates ED[17] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_31	         31	// Bidirectional. Settings for current instrument: indicates ED[18] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_32	         32	// Bidirectional. Settings for current instrument: indicates ED[19] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_33	         33	// Bidirectional. Settings for current instrument: indicates ED[20] is about to be sent with CC 105. 
+	//
+    /* MrMep: this could be wrong on the google Doc */
+    #define MIDI_CC_104_VALUE_34	         34	// Bidirectional. Settings for current instrument: indicates that lsb of learned note trigger pressure is about to be sent on CC 105
+    #define MIDI_CC_104_VALUE_35	         35	// Bidirectional. Settings for current instrument: indicates that msb of learned note trigger pressure is about to be sent on CC 105
+    /* 36-39 unused */
+
+    /* Switches array - see defines above */
+    #define MIDI_CC_104_VALUE_40             40 //  Bidirectional. Settings for current instrument: indicates that switches[0] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_41             41 //  Bidirectional. Settings for current instrument: indicates that switches[1] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_42             42 //  Bidirectional. Settings for current instrument: indicates that switches[2] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_43             43 //  Bidirectional. Settings for current instrument: indicates that switches[3] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_44             44 //  Bidirectional. Settings for current instrument: indicates that switches[4] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_45             45 //  Bidirectional. Settings for current instrument: indicates that switches[5] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_46             46 //  Bidirectional. Settings for current instrument: indicates that switches[6] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_47             47 //  Bidirectional. Settings for current instrument: indicates that switches[7] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_48             48 //  Bidirectional. Settings for current instrument: indicates that switches[8] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_49             49 //  Bidirectional. Settings for current instrument: indicates that switches[9] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_50             50 //  Bidirectional. Settings for current instrument: indicates that switches[10] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_51             51 //  Bidirectional. Settings for current instrument: indicates that switches[11] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_52             52 //  Bidirectional. Settings for current instrument: indicates that switches[12] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_53             53 //  Bidirectional. Settings for current instrument: indicates that switches[13] is about to be sent with CC 105. UNUSED?
+    //
+    /* 54-60 unused */
+    //MrMep: The following 2 must be wrong on the google doc
+    #define MIDI_CC_104_VALUE_61	         61	//  Bidirectional. Settings for current instrument: MIDI bend range is about to be sent on CC 105
+    #define MIDI_CC_104_VALUE_62	         62	//  Bidirectional. Settings for current instrument: MIDI channel is about to be sent on CC 105
+    /* 62-69 unused */
+
+	/* more expression or drones variables (ED array) 
+     * can be extended to 127  for WARBL2, e.g. IMU functionality. If more variables are needed CC109 can also be used to indicate additional "pressureReceiveMode" options
+     */
+    #define MIDI_CC_104_VALUE_70    	     70	// Bidirectional. Settings for current instrument: indicates ED[21] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_71    	     71	// Bidirectional. Settings for current instrument: indicates ED[22] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_72    	     72	// Bidirectional. Settings for current instrument: indicates ED[23] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_73    	     73	// Bidirectional. Settings for current instrument: indicates ED[24] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_74    	     74	// Bidirectional. Settings for current instrument: indicates ED[25] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_75    	     75	// Bidirectional. Settings for current instrument: indicates ED[26] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_76    	     76	// Bidirectional. Settings for current instrument: indicates ED[27] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_77    	     77	// Bidirectional. Settings for current instrument: indicates ED[28] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_78    	     78	// Bidirectional. Settings for current instrument: indicates ED[29] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_79    	     79	// Bidirectional. Settings for current instrument: indicates ED[30] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_80    	     80	// Bidirectional. Settings for current instrument: indicates ED[31] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_81    	     81	// Bidirectional. Settings for current instrument: indicates ED[32] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_82    	     82	// Bidirectional. Settings for current instrument: indicates ED[33] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_83    	     83	// Bidirectional. Settings for current instrument: indicates ED[34] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_84    	     84	// Bidirectional. Settings for current instrument: indicates ED[35] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_85    	     85	// Bidirectional. Settings for current instrument: indicates ED[36] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_86    	     86	// Bidirectional. Settings for current instrument: indicates ED[37] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_87    	     87	// Bidirectional. Settings for current instrument: indicates ED[38] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_88    	     88	// Bidirectional. Settings for current instrument: indicates ED[39] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_89    	     89	// Bidirectional. Settings for current instrument: indicates ED[40] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_90    	     90	// Bidirectional. Settings for current instrument: indicates ED[41] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_91    	     91	// Bidirectional. Settings for current instrument: indicates ED[42] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_92    	     92	// Bidirectional. Settings for current instrument: indicates ED[43] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_93    	     93	// Bidirectional. Settings for current instrument: indicates ED[44] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_94    	     94	// Bidirectional. Settings for current instrument: indicates ED[45] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_95    	     95	// Bidirectional. Settings for current instrument: indicates ED[46] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_96    	     96	// Bidirectional. Settings for current instrument: indicates ED[47] is about to be sent with CC 105. 
+    #define MIDI_CC_104_VALUE_97    	     97	// Bidirectional. Settings for current instrument: indicates ED[48] is about to be sent with CC 105. 
+    //
+    /* 98-127 unused */
+
+#define MIDI_CC_105                         105 // Bidirectional - From Warbl. Values 0-127. Settings for current instrument: value of above variable indicated by CC 104 or variable indicated by CC 109 (see below)
+
+#define MIDI_CC_106                         106 // from WARBL & from Config Tool.  Various values as follows:
+    //MIDI Channels
+    #define MIDI_CC_106_VALUE_0	              0	//Bidirectional. MIDI channel 1
+    #define MIDI_CC_106_VALUE_1	              1	//Bidirectional. MIDI channel 2
+    #define MIDI_CC_106_VALUE_2	              2	//Bidirectional. MIDI channel 3
+    #define MIDI_CC_106_VALUE_3	              3	//Bidirectional. MIDI channel 4
+    #define MIDI_CC_106_VALUE_4	              4	//Bidirectional. MIDI channel 5
+    #define MIDI_CC_106_VALUE_5	              5	//Bidirectional. MIDI channel 6
+    #define MIDI_CC_106_VALUE_6	              6	//Bidirectional. MIDI channel 7
+    #define MIDI_CC_106_VALUE_7	              7	//Bidirectional. MIDI channel 8
+    #define MIDI_CC_106_VALUE_8	              8	//Bidirectional. MIDI channel 9
+    #define MIDI_CC_106_VALUE_9	              9	//Bidirectional. MIDI channel 10
+    #define MIDI_CC_106_VALUE_10	         10	//Bidirectional. MIDI channel 11
+    #define MIDI_CC_106_VALUE_11	         11	//Bidirectional. MIDI channel 12
+    #define MIDI_CC_106_VALUE_12	         12	//Bidirectional. MIDI channel 13
+    #define MIDI_CC_106_VALUE_13	         13	//Bidirectional. MIDI channel 14
+    #define MIDI_CC_106_VALUE_14	         14	//Bidirectional. MIDI channel 15
+    #define MIDI_CC_106_VALUE_15	         15	//Bidirectional. MIDI channel 16
+    //
+    #define MIDI_CC_106_VALUE_16	         16	//Bidirectional. custom vibrato off
+    #define MIDI_CC_106_VALUE_17	         17	//Bidirectional. custom vibrato on
+    /* 18-19 unused */
+
+    //Vibrato holes
+    #define MIDI_CC_106_VALUE_20	         20 //Bidirectional. enable vibrato hole, 0	
+    #define MIDI_CC_106_VALUE_21	         21 //Bidirectional. enable vibrato hole, 1	
+    #define MIDI_CC_106_VALUE_22	         22 //Bidirectional. enable vibrato hole, 2	
+    #define MIDI_CC_106_VALUE_23	         23 //Bidirectional. enable vibrato hole, 3	
+    #define MIDI_CC_106_VALUE_24	         24 //Bidirectional. enable vibrato hole, 4	
+    #define MIDI_CC_106_VALUE_25	         25 //Bidirectional. enable vibrato hole, 5	
+    #define MIDI_CC_106_VALUE_26	         26 //Bidirectional. enable vibrato hole, 6	
+    #define MIDI_CC_106_VALUE_27	         27 //Bidirectional. enable vibrato hole, 7	
+    #define MIDI_CC_106_VALUE_28	         28 //Bidirectional. enable vibrato hole, 8	
+    /* 29 unused */
+    #define MIDI_CC_106_VALUE_30	         30 //Bidirectional. disable vibrato hole, 0
+    #define MIDI_CC_106_VALUE_31	         31 //Bidirectional. disable vibrato hole, 1
+    #define MIDI_CC_106_VALUE_32	         32 //Bidirectional. disable vibrato hole, 2
+    #define MIDI_CC_106_VALUE_33	         33 //Bidirectional. disable vibrato hole, 3
+    #define MIDI_CC_106_VALUE_34	         34 //Bidirectional. disable vibrato hole, 4
+    #define MIDI_CC_106_VALUE_35	         35 //Bidirectional. disable vibrato hole, 5
+    #define MIDI_CC_106_VALUE_36	         36 //Bidirectional. disable vibrato hole, 6
+    #define MIDI_CC_106_VALUE_37	         37 //Bidirectional. disable vibrato hole, 7
+    #define MIDI_CC_106_VALUE_38	         38 //Bidirectional. disable vibrato hole, 8
+    //
+    #define MIDI_CC_106_VALUE_39	         39	//Bidirectional. calibrate at startup
+    #define MIDI_CC_106_VALUE_40	         40	//Bidirectional. use learned calibration
+    #define MIDI_CC_106_VALUE_41	         41	// from Config Tool. learn initial note on pressure
+    #define MIDI_CC_106_VALUE_42	         42	// from Config Tool. autocalibrate bell sensor only	
+    #define MIDI_CC_106_VALUE_43	         43	// from Config Tool. learn drones on pressure
+    /* 44 unused */
+    #define MIDI_CC_106_VALUE_45	         45	// from Config Tool. save current sensor calibration as factory calibration (this is on a special webpage for me to use when I first program WARBL)
+    #define MIDI_CC_106_VALUE_46	         46	//Bidirectional.invert off
+    #define MIDI_CC_106_VALUE_47	         47	//Bidirectional.invert on
+	#define MIDI_CC_106_VALUE_48	         48	//from WARBL. next message will be byte 1 of debug message
+	#define MIDI_CC_106_VALUE_49	         49	//from WARBL. next message will be byte 2 of debug message
+	#define MIDI_CC_106_VALUE_50	         50	//from WARBL. next message will be byte 3 of debug message (midi requires three bytes to send/receive an int because MIDI bytes are actually only 7 bits)
+	#define MIDI_CC_106_VALUE_51	         51	//from WARBL. Indicates end of two-byte message 
+	#define MIDI_CC_106_VALUE_52	         52	//from WARBL. Indicates end of three-byte message 
+	#define MIDI_CC_106_VALUE_53	         53	//Bidirectional. Used to tell the Config Tool to include the uilleann regulators fingering pattern (used in a custom version of the code)	
+    #define MIDI_CC_106_VALUE_54	         54	//from Config Tool. WARBL2 calibrate IMU
+    #define MIDI_CC_106_VALUE_55             55 //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+    #define MIDI_CC_106_VALUE_56             56 //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+    #define MIDI_CC_106_VALUE_57             57 //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+    /* 58-59 unused */
+    #define MIDI_CC_106_VALUE_60	         60	// from Config Tool. WARBL2 recenter yaw
+    /* 61-69 unused */
+    #define MIDI_CC_106_VALUE_70	         70	//from WARBL. WARBL2 battery voltage
+	#define MIDI_CC_106_VALUE_71	         71	//from WARBL. WARBL2 charging status
+
+    //MrMep: LSB and MSB are inverted in the Google Doc
+	#define MIDI_CC_106_VALUE_72	         72	//from WARBL. WARBL2 BLE connection interval low byte
+	#define MIDI_CC_106_VALUE_73	         73	//from WARBL. WARBL2 BLE connection interval high byte
+	#define MIDI_CC_106_VALUE_74	         74	//from WARBL. WARBL2 battery percentage
+    /* 75-99	unused -- can be used for WARBL2 */
+
+    //Button Actions, see above 102  90/99
+	#define MIDI_CC_106_VALUE_100	        100	//Bidirectional. button action 0 
+	#define MIDI_CC_106_VALUE_101	        101	//Bidirectional. button action 1
+	#define MIDI_CC_106_VALUE_102	        102	//Bidirectional. button action 2 
+	#define MIDI_CC_106_VALUE_103	        103	//Bidirectional. button action 3 
+	#define MIDI_CC_106_VALUE_104	        104	//Bidirectional. button action 4 
+	#define MIDI_CC_106_VALUE_105	        105	//Bidirectional. button action 5 
+	#define MIDI_CC_106_VALUE_106	        106	//Bidirectional. button action 6 
+	#define MIDI_CC_106_VALUE_107	        107	//Bidirectional. button action 7 
+	#define MIDI_CC_106_VALUE_108	        108	//Bidirectional. button action 8 
+	#define MIDI_CC_106_VALUE_109	        109	//Bidirectional. button action 9 
+	#define MIDI_CC_106_VALUE_110	        110	//Bidirectional. button action 10 
+	#define MIDI_CC_106_VALUE_111	        111	//Bidirectional. button action 11
+	#define MIDI_CC_106_VALUE_112	        112	//Bidirectional. button action 12
+	#define MIDI_CC_106_VALUE_113	        113	//Bidirectional. button action 13
+	#define MIDI_CC_106_VALUE_114	        114	//Bidirectional. button action 14
+	#define MIDI_CC_106_VALUE_115	        115	//Bidirectional. button action 15
+	#define MIDI_CC_106_VALUE_116	        116	//Bidirectional. button action 16
+	#define MIDI_CC_106_VALUE_117	        117	//Bidirectional. button action 17
+	#define MIDI_CC_106_VALUE_118	        118	//Bidirectional. button action 18
+	#define MIDI_CC_106_VALUE_119	        119	//Bidirectional. button action 19
+	#define MIDI_CC_106_VALUE_120	        120	//Bidirectional. button action 20
+	#define MIDI_CC_106_VALUE_121	        121	//Bidirectional. button action 21
+	#define MIDI_CC_106_VALUE_122	        122	//Bidirectional. button action 22
+	#define MIDI_CC_106_VALUE_123	        123	//Bidirectional. button action 23
+	#define MIDI_CC_106_VALUE_124	        124	//Bidirectional. button action 24
+	#define MIDI_CC_106_VALUE_125	        125	//Bidirectional. button action 25
+	#define MIDI_CC_106_VALUE_126	        126	//Bidirectional. button action 26
+	#define MIDI_CC_106_VALUE_127	        127	//Bidirectional. button action 27
+    //
+
+#define MIDI_CC_107                         107 // From WARBL. Values 0-127	- MIDI byte 2
+#define MIDI_CC_108                         108 // From WARBL. Values 0-127	- MIDI byte 3
+
+#define MIDI_CC_109                         109 // From WARBL. Values as follows:
+    #define MIDI_CC_109_OFFSET              200 //Value added to received CC 109, to distinguish them from those from CC_104
+    //IMU Settings Array - see defines above
+    #define MIDI_CC_109_VALUE_0	              0	// Bidirectional. Settings for current instrument: indicates IMUsettings[0] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_1	              1	// Bidirectional. Settings for current instrument: indicates IMUsettings[1] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_2	              2	// Bidirectional. Settings for current instrument: indicates IMUsettings[2] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_3	              3	// Bidirectional. Settings for current instrument: indicates IMUsettings[3] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_4	              4	// Bidirectional. Settings for current instrument: indicates IMUsettings[4] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_5	              5	// Bidirectional. Settings for current instrument: indicates IMUsettings[5] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_6	              6	// Bidirectional. Settings for current instrument: indicates IMUsettings[6] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_7	              7	// Bidirectional. Settings for current instrument: indicates IMUsettings[7] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_8	              8	// Bidirectional. Settings for current instrument: indicates IMUsettings[8] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_9	              9	// Bidirectional. Settings for current instrument: indicates IMUsettings[9] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_10	         10	// Bidirectional. Settings for current instrument: indicates IMUsettings[10] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_11             11	// Bidirectional. Settings for current instrument: indicates IMUsettings[11] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_12             12	// Bidirectional. Settings for current instrument: indicates IMUsettings[12] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_13             13	// Bidirectional. Settings for current instrument: indicates IMUsettings[13] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_14             14	// Bidirectional. Settings for current instrument: indicates IMUsettings[14] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_15             15	// Bidirectional. Settings for current instrument: indicates IMUsettings[15] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_16             16 // Bidirectional. Settings for current instrument: indicates IMUsettings[16] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_17             17	// Bidirectional. Settings for current instrument: indicates IMUsettings[17] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_18             18	// Bidirectional. Settings for current instrument: indicates IMUsettings[18] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_19             19	// Bidirectional. Settings for current instrument: indicates IMUsettings[19] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_20             20	// Bidirectional. Settings for current instrument: indicates IMUsettings[20] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_21             21	// Bidirectional. Settings for current instrument: indicates IMUsettings[21] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_22             22	// Bidirectional. Settings for current instrument: indicates IMUsettings[22] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_23             23	// Bidirectional. Settings for current instrument: indicates IMUsettings[23] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_24             24	// Bidirectional. Settings for current instrument: indicates IMUsettings[24] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_25             25	// Bidirectional. Settings for current instrument: indicates IMUsettings[25] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_26             26	// Bidirectional. Settings for current instrument: indicates IMUsettings[26] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_27	         27 // Bidirectional. Settings for current instrument: indicates IMUsettings[27] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_28             28	// Bidirectional. Settings for current instrument: indicates IMUsettings[28] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_29             29	// Bidirectional. Settings for current instrument: indicates IMUsettings[29] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_30             30	// Bidirectional. Settings for current instrument: indicates IMUsettings[30] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_31             31	// Bidirectional. Settings for current instrument: indicates IMUsettings[31] is about to be sent with CC 105. 
+    #define MIDI_CC_109_VALUE_32             32	// Bidirectional. Settings for current instrument: indicates IMUsettings[32] is about to be sent with CC 105. 
+    /* 33-99	unused -- can be used to extend above array or for other variables */
+
+    #define MIDI_CC_109_VALUE_100           100 // Bidirectional. Indicates that  WARBL2 custom fingering chart 1 is about to be sent on CC 105. Same command from WARBL indicates that all 256 messages were received.
+    #define MIDI_CC_109_VALUE_101           101 // Bidirectional. Indicates that  WARBL2 custom fingering chart 2 is about to be sent on CC 105. 
+    #define MIDI_CC_109_VALUE_102           102 // Bidirectional. Indicates that  WARBL2 custom fingering chart 3 is about to be sent on CC 105. 
+    #define MIDI_CC_109_VALUE_103           103 // Bidirectional. Indicates that  WARBL2 custom fingering chart 4 is about to be sent on CC 105. 
+	/* 104-126	unused */
+    #define MIDI_CC_109_VALUE_127	        127	 // From WARBL. Indicates button/gesture action will be sent on CC 105
+
+
+#define MIDI_CC_110                         110 // From WARBL. Values 0-127	- firmware version
+#define MIDI_CC_111                         111 // Bidirectional. Values 0-127	- note shift for mode 0
+    #define MIDI_CC_111_VALUE_109           109 // Bidirectional. Hidden sticks mode - Same for 112 and 113
+#define MIDI_CC_112                         112 // Bidirectional. Values 0-127	- note shift for mode 1
+#define MIDI_CC_113                         113 // Bidirectional. Values 0-127	- note shift for mode 2
+
+#define MIDI_CC_114                         114 // From WARBL. Values 0-127	- highest 2 bytes of holeCovered (int indicating which holes are currently covered)
+#define MIDI_CC_115                         115 // From WARBL. Values 0-127	- lowest 7 bytes of holeCovered
+#define MIDI_CC_116                         116 // From WARBL. Values 0-127	- LSB of pressure
+#define MIDI_CC_117                         117 // Bidirectional. Values 0-100	- vibrato depth (cents)
+#define MIDI_CC_118                         118 // From WARBL. Values 0-127	- MSB of pressure
+#define MIDI_CC_119                         119 // From WARBL. Values 0-127	- value of above variable indicated by CC 106
+
+#define MIDI_CC_123                         123 // MIDI PANIC
+//END of MIDI Numerical constants
+
+//Human readable constants
+/* Commands - VALUES ONLY */
+#define MIDI_SAVE_CALIB                      MIDI_CC_102_VALUE_19  //from Config Tool. Save optical sensor calibration
+#define MIDI_EXIT_COMM_MODE                  MIDI_CC_102_VALUE_104 //from Config Tool. exit communication mode (previously 102 99)
+#define MIDI_SAVE_AS_DEFAULTS_CURRENT        MIDI_CC_102_VALUE_123 //from Config Tool. save as defaults for current mode
+#define MIDI_SAVE_AS_DEFAULTS_ALL            MIDI_CC_102_VALUE_124 //from Config Tool. save as defaults for  all instruments
+#define MIDI_RESTORE_FACTORY                 MIDI_CC_102_VALUE_125 //from Config Tool. restore factory settings
+#define MIDI_ENTER_COMM_MODE                 MIDI_CC_102_VALUE_126 //from Config Tool. enter communication mode
+#define MIDI_START_CALIB                     MIDI_CC_102_VALUE_127 //from Config Tool. begin autocalibration
+
+#define MIDI_STARTUP_CALIB                   MIDI_CC_106_VALUE_39 //Bidirectional. calibrate at startup
+#define MIDI_USE_LEARNED_CALIB               MIDI_CC_106_VALUE_40 //Bidirectional. use learned calibration
+#define MIDI_LEARN_INITIAL_NOTE_PRESS        MIDI_CC_106_VALUE_41 // from Config Tool. learn initial note on pressure
+#define MIDI_CALIB_BELL_SENSOR               MIDI_CC_106_VALUE_42  // from Config Tool. autocalibrate bell sensor only	
+#define MIDI_LEARN_DRONES_PRESSURE           MIDI_CC_106_VALUE_43  // from Config Tool. learn drones on pressure
+#define MIDI_SAVE_CALIB_AS_FACTORY           MIDI_CC_106_VALUE_45 // from Config Tool. save current sensor calibration as factory calibration (this is on a special webpage for me to use when I first program WARBL)
+#define MIDI_CALIB_IMU                       MIDI_CC_106_VALUE_54 //from Config Tool. WARBL2 calibrate IMU
+#define MIDI_CENTER_YAW                      MIDI_CC_106_VALUE_60  // from Config Tool. WARBL2 recenter yaw
+
+#define MIDI_STICKS_MODE                     MIDI_CC_111_VALUE_109 // Bidirectional. Hidden sticks mode - Same for 112 and 113
+
+/* START - END Values */
+#define MIDI_CALIB_MSGS_START                MIDI_CC_102_VALUE_1   // Start of Calibration correction messages
+#define MIDI_CALIB_MSGS_END                  MIDI_CC_102_VALUE_18  // End of Calibration correction messages
+#define MIDI_MAX_CALIB_MSGS_START            MIDI_CC_102_VALUE_20  // Start of Calibration max values reached messages
+#define MIDI_MAX_CALIB_MSGS_END              MIDI_CC_102_VALUE_28  // End of Calibration max values reached messages
+#define MIDI_FINGERING_PATTERN_MODE_START    MIDI_CC_102_VALUE_30  // Bidirectional. indicates that the next command will be the fingering pattern for instrument 1
+#define MIDI_FINGERING_PATTERN_START         MIDI_CC_102_VALUE_33  // Bidirectional. first fingering pattern is tin whistle
+#define MIDI_FINGERING_PATTERN_END           MIDI_CC_102_VALUE_59  // Bidirectional. Bansuri
+#define MIDI_CURRENT_MODE_START              MIDI_CC_102_VALUE_60  // Bidirectional. current instrument (mode variable) is  0
+#define MIDI_PB_MODE_START                   MIDI_CC_102_VALUE_70  // Bidirectional. Settings for current instrument: Pitchbend mode 0
+#define MIDI_BREATH_MODE_START               MIDI_CC_102_VALUE_80  // Bidirectional. Settings for current instrument: Breath mode 0
+#define MIDI_DEFAULT_MODE_START              MIDI_CC_102_VALUE_85  // Bidirectional. default instrument is 0 - (if Config Tool sends 85 to WARBL, WARBL sets current instrument as default)
+#define MIDI_GESTURE_START                   MIDI_CC_102_VALUE_90  // Bidirectional. Sending data for click 1 (dropdown row 0)
+#define MIDI_CUST_FINGERING_PATTERN_START    MIDI_CC_102_VALUE_100 // Bidirectional. WARBL2 custom fingering chart 1
+#define MIDI_CUST_FINGERING_PATTERN_END      MIDI_CC_102_VALUE_103 // Bidirectional. WARBL2 custom fingering chart 4
+#define MIDI_ACTION_MIDI_START               MIDI_CC_102_VALUE_112 // Bidirectional. send midi note on/note off
+
+#define MIDI_PRESS_SELECT_VARS_START         MIDI_CC_104_VALUE_1  // Bidirectional. Settings for current instrument: indicates ""bag threshold"" is about to be sent with CC 105.
+#define MIDI_PRESS_SELECT_VARS_END           MIDI_CC_104_VALUE_12  // Bidirectional. Settings for current instrument: indicates "breath  drop time" is about to be sent with CC 105.
+#define MIDI_ED_VARS_START                   MIDI_CC_104_VALUE_13  // Bidirectional. Settings for current instrument: indicates ED[0] is about to be sent with CC 105. 
+#define MIDI_ED_VARS_END                     MIDI_CC_104_VALUE_33  // Bidirectional. Settings for current instrument: indicates ED[20] is about to be sent with CC 105. 
+#define MIDI_SWITCHES_VARS_START             MIDI_CC_104_VALUE_40  // Bidirectional. Settings for current instrument: indicates that switches[0] is about to be sent with CC 105. 
+#define MIDI_SWITCHES_VARS_END               MIDI_CC_104_VALUE_53  // Bidirectional. Settings for current instrument: indicates that switches[13] is about to be sent with CC 105. UNUSED?
+#define MIDI_ED_VARS2_START                  MIDI_CC_104_VALUE_70  // Bidirectional. Settings for current instrument: indicates ED[21] is about to be sent with CC 105. 
+#define MIDI_ED_VARS2_END                    MIDI_CC_104_VALUE_97  // Bidirectional. Settings for current instrument: indicates ED[48] is about to be sent with CC 105. 
+#define MIDI_ED_VARS_NUMBER                  MIDI_ED_VARS_END - MIDI_ED_VARS_START + 1 //ED array number of vars for the first slot
+#define MIDI_ED_VARS2_OFFSET                 MIDI_ED_VARS2_START - MIDI_ED_VARS_NUMBER //ED array index for 2nd slot of MIDI Msgs
+
+#define MIDI_ACTION_MIDI_CHANNEL_END         MIDI_CC_106_VALUE_15 //Bidirectional. MIDI channel 16
+
+#define MIDI_ENA_VIBRATO_HOLES_START         MIDI_CC_106_VALUE_20  //Bidirectional. enable vibrato hole, 0	
+#define MIDI_ENA_VIBRATO_HOLES_END           MIDI_CC_106_VALUE_28  //Bidirectional. enable vibrato hole, 8	
+#define MIDI_DIS_VIBRATO_HOLES_START         MIDI_CC_106_VALUE_30  //Bidirectional. disable vibrato hole, 0	
+#define MIDI_DIS_VIBRATO_HOLES_END           MIDI_CC_106_VALUE_38  //Bidirectional. disable vibrato hole, 8	
+#define MIDI_WARBL2_SETTINGS_START           MIDI_CC_106_VALUE_55  //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+#define MIDI_WARBL2_SETTINGS_END             MIDI_CC_106_VALUE_74  //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+#define MIDI_BUTTON_ACTIONS_START            MIDI_CC_106_VALUE_100 //Bidirectional. button action 0 
+
+#define MIDI_CUSTOM_CHARTS_START             MIDI_CC_109_VALUE_100 //Beginning of WARBL2 CustomCharts
+#define MIDI_CUSTOM_CHARTS_END               MIDI_CC_109_VALUE_103 //End of WARBL2 CustomCharts
+#define MIDI_CUSTOM_CHARTS_OFFSET_START      MIDI_CC_109_OFFSET + MIDI_CUSTOM_CHARTS_START //Beginning of WARBL2 CustomCharts
+#define MIDI_CUSTOM_CHARTS_OFFSET_END        MIDI_CC_109_OFFSET + MIDI_CUSTOM_CHARTS_END //End of WARBL2 CustomCharts
+
+/* Various single Values */
+#define MIDI_MOMENTARY_OFF                   MIDI_CC_102_VALUE_117 // Bidirectional. momentary off
+#define MIDI_MOMENTARY_ON                    MIDI_CC_102_VALUE_118 // Bidirectional. momentary on
+
+#define MIDI_LEARNED_PRESS_LSB               MIDI_CC_104_VALUE_34  // Bidirectional. Settings for current instrument: indicates that lsb of learned note trigger pressure is about to be sent on CC 105
+#define MIDI_LEARNED_PRESS_MSB               MIDI_CC_104_VALUE_35  // Bidirectional. Settings for current instrument: indicates that msb of learned note trigger pressure is about to be sent on CC 105
+#define MIDI_BEND_RANGE                      MIDI_CC_104_VALUE_61  // Bidirectional. Settings for current instrument: MIDI bend range is about to be sent on CC 105
+#define MIDI_MIDI_CHANNEL                    MIDI_CC_104_VALUE_62  // Bidirectional. Settings for current instrument: MIDI channel is about to be sent on CC 105
+
+#define MIDI_BLE_INTERVAL_LSB                MIDI_CC_106_VALUE_72 //from WARBL. WARBL2 BLE connection interval low byte
+#define MIDI_BLE_INTERVAL_MSB                MIDI_CC_106_VALUE_73 //from WARBL. WARBL2 BLE connection interval high byte
+
+#define MIDI_CUSTOM_CHARTS_START             MIDI_CC_109_VALUE_100 //Beginning of WARBL2 CustomCharts
+
+/* General sendMidi Args - NO VALUE - <CONTROL_CHANGE, MIDI channel, CC Number> */
+#define MIDI_SEND_CC                        CONTROL_CHANGE, MIDI_CONFIG_TOOL_CHANNEL
+
+#define MIDI_CC_102_MSG                     MIDI_SEND_CC, MIDI_CC_102
+#define MIDI_CC_103_MSG                     MIDI_SEND_CC, MIDI_CC_103
+#define MIDI_CC_104_MSG                     MIDI_SEND_CC, MIDI_CC_104
+#define MIDI_CC_105_MSG                     MIDI_SEND_CC, MIDI_CC_105
+#define MIDI_CC_106_MSG                     MIDI_SEND_CC, MIDI_CC_106
+#define MIDI_CC_107_MSG                     MIDI_SEND_CC, MIDI_CC_107
+#define MIDI_CC_108_MSG                     MIDI_SEND_CC, MIDI_CC_108
+#define MIDI_CC_109_MSG                     MIDI_SEND_CC, MIDI_CC_109
+#define MIDI_CC_110_MSG                     MIDI_SEND_CC, MIDI_CC_110
+
+#define MIDI_CC_114_MSG                     MIDI_SEND_CC, MIDI_CC_114
+#define MIDI_CC_115_MSG                     MIDI_SEND_CC, MIDI_CC_115
+#define MIDI_CC_116_MSG                     MIDI_SEND_CC, MIDI_CC_116
+#define MIDI_CC_117_MSG                     MIDI_SEND_CC, MIDI_CC_117
+#define MIDI_CC_118_MSG                     MIDI_SEND_CC, MIDI_CC_118
+#define MIDI_CC_119_MSG                     MIDI_SEND_CC, MIDI_CC_119
+
+/* Full sendMidi Args - WITH VALUES - <CONTROL_CHANGE, MIDI channel, CC Number, CC Value> */
+#define MIDI_SEND_LEARNED_PRESSURE_LSB	    MIDI_CC_104_MSG, MIDI_LEARNED_PRESS_LSB  // Bidirectional. Settings for current instrument: indicates that lsb of learned note trigger pressure is about to be sent on CC 105
+#define MIDI_SEND_LEARNED_PRESSURE_MSB	    MIDI_CC_104_MSG, MIDI_LEARNED_PRESS_MSB  // Bidirectional. Settings for current instrument: indicates that msb of learned note trigger pressure is about to be sent on CC 105
+#define MIDI_SEND_DRONES_PRESSURE_LSB	    MIDI_CC_104_MSG, MIDI_CC_104_VALUE_32    // Bidirectional. Settings for current instrument: indicates that lsb of drones pressure is about to be sent on CC 105
+#define MIDI_SEND_DRONES_PRESSURE_MSB	    MIDI_CC_104_MSG, MIDI_CC_104_VALUE_33    // Bidirectional. Settings for current instrument: indicates that msb of drones pressure is about to be sent on CC 105
+#define MIDI_SEND_BEND_RANGE                MIDI_CC_104_MSG, MIDI_CC_104_VALUE_61  // Bidirectional. Settings for current instrument: MIDI bend range is about to be sent on CC 105
+#define MIDI_SEND_MIDI_CHANNEL              MIDI_CC_104_MSG, MIDI_CC_104_VALUE_62  // Bidirectional. Settings for current instrument: MIDI channel is about to be sent on CC 105
+
+
+#define MIDI_SEND_BATTERY_VOLTAGE           MIDI_CC_106_MSG, MIDI_CC_106_VALUE_70  //from WARBL. WARBL2 battery voltage
+#define MIDI_SEND_BATTERY_CHARGE_STATUS     MIDI_CC_106_MSG, MIDI_CC_106_VALUE_71  //from WARBL. WARBL2 charging status
+#define MIDI_SEND_BATTERY_CHARGE_PERC	    MIDI_CC_106_MSG, MIDI_CC_106_VALUE_74  //from WARBL. WARBL2 battery percentage
+
+#define MIDI_SEND_BUTTON_ACTION             MIDI_CC_109_MSG, MIDI_CC_109_VALUE_127 // From WARBL. Indicates button/gesture action will be sent on CC 105
+
+#define MIDI_CUSTOM_CHARTS_RCVD	            MIDI_CC_109_MSG, MIDI_CC_109_VALUE_100 //from WARBL. WARBL2 Custom fingering charts - indicate success
+
+//END of Human readable constants
+/* END of MIDI Config Tool Constants */
+
+
 /* EEPROM Addresses */
 #define EEPROM_BASELINE_CALIB_START        1 // values 0-255 baseline sensor calibrations - 9 bytes 1-9
 /* 10-17 unused */
@@ -315,3 +855,6 @@
                                              // 4512-4767		Custom fingering chart 3
                                              // 4768-5023		Custom fingering chart 4
 /* 5024-16383 other ~11 KB unused */
+
+/* END of EEPROM Addresses */
+

--- a/warbl2_firmware/warbl2_firmware.ino
+++ b/warbl2_firmware/warbl2_firmware.ino
@@ -148,7 +148,7 @@ byte breathMode = kPressureBreath;            // The desired presure sensor beha
 unsigned int vibratoDepth = 1024;             // Vibrato depth from 0 (no vibrato) to 8191 (one semitone)
 bool useLearnedPressure = 0;                  // Whether we use learned pressure for note on threshold, or we use calibration pressure from startup
 byte midiBendRange = 2;                       // +/- semitones that the midi bend range represents
-byte mainMidiChannel = 1;                     // Current MIDI channel to send notes on
+byte mainMidiChannel = MIDI_DEFAULT_MAIN_CHANNEL;                     // Current MIDI channel to send notes on
 
 
 // These are containers for the above variables, storing the value used by the three different instruments (modes).  First variable in array is for instrument 0, etc.
@@ -291,7 +291,7 @@ int adjvibdepth;                                                                
 bool noteon = 0;      // Whether a note is currently turned on
 bool shiftState = 0;  // Whether the octave is shifted (could be combined with octaveShift)
 int8_t shift = 0;     // The total amount of shift up or down from the base note 62 (D). This takes into account octave shift and note shift.
-byte velocity = 127;  // MIDI note velocity
+byte velocity = MIDI_DEFAULT_VELOCITY;  // MIDI note velocity
 
 
 // Tonehole calibration variables

--- a/webconfig/configure.html
+++ b/webconfig/configure.html
@@ -2467,6 +2467,7 @@
    </script>
    <script src='js/WebAudioFontPlayer.js'></script>
    <script src='js/0650_SBLive_sf2.js'></script>
+   <script src="js/constants.js"></script>
    <script src="js/midi.js"></script>
    <script src="js/d3.min.js"></script>
 </html>

--- a/webconfig/configureForApp.html
+++ b/webconfig/configureForApp.html
@@ -2467,6 +2467,7 @@
    </script>
    <script src='js/WebAudioFontPlayer.js'></script>
    <script src='js/0650_SBLive_sf2.js'></script>
+   <script src="js/constants.js"></script>
    <script src="js/midi.js"></script>
    <script src="js/d3.min.js"></script>
 </html>

--- a/webconfig/js/constants.js
+++ b/webconfig/js/constants.js
@@ -1,0 +1,559 @@
+
+/* MIDI Config Tool Constants */
+
+// To Be Sync'd with Defines.h in firmware
+
+//General constants
+const MIDI_DEFAULT_MAIN_CHANNEL = 1; // Default MIDI channel to send notes on
+const MIDI_CONFIG_TOOL_CHANNEL = 7; // Config Tool MIDI channel
+const MIDI_DEFAULT_VELOCITY = 127; // 
+
+//MIDI Human readable constants: see below
+
+/* Numerical constants
+    * Some cc values are reserved from Config Tool or from WARBL
+    * Bidirectional Communication: same commands both ways with same cc/value 
+*/
+const MIDI_CC_102 = 102; // from WARBL & from Config Tool. Various values as follows:
+const MIDI_CC_102_VALUE_0 = 0; // unused
+// sensor calibration messages
+    const MIDI_CC_102_VALUE_1 = 1; //from Config Tool. bell sensor down
+    const MIDI_CC_102_VALUE_2 = 2; //from Config Tool. bell sensor up
+    const MIDI_CC_102_VALUE_3 = 3; //from Config Tool. R4 down
+    const MIDI_CC_102_VALUE_4 = 4; //from Config Tool. R4 up
+    const MIDI_CC_102_VALUE_5 = 5; //from Config Tool. R3 down
+    const MIDI_CC_102_VALUE_6 = 6; //from Config Tool. R3 up
+    const MIDI_CC_102_VALUE_7 = 7; //from Config Tool. R2 down
+    const MIDI_CC_102_VALUE_8 = 8; //from Config Tool. R2 up
+    const MIDI_CC_102_VALUE_9 = 9; //from Config Tool. R1 down
+    const MIDI_CC_102_VALUE_10 = 10; //from Config Tool. R1 up
+    const MIDI_CC_102_VALUE_11 = 11; //from Config Tool. L3 down
+    const MIDI_CC_102_VALUE_12 = 12; //from Config Tool. L3 up
+    const MIDI_CC_102_VALUE_13 = 13; //from Config Tool. L2 down
+    const MIDI_CC_102_VALUE_14 = 14; //from Config Tool. L2 up
+    const MIDI_CC_102_VALUE_15 = 15; //from Config Tool. L1 down
+    const MIDI_CC_102_VALUE_16 = 16; //from Config Tool. L1 up
+    const MIDI_CC_102_VALUE_17 = 17; //from Config Tool. Lthumb down
+    const MIDI_CC_102_VALUE_18 = 18; //from Config Tool. Lthumb up		
+    const MIDI_CC_102_VALUE_19 = 19; //from Config Tool. Save optical sensor calibration
+    const MIDI_CC_102_VALUE_20 = 20; //from WARBL. bell sensor max value reached
+    const MIDI_CC_102_VALUE_21 = 21; //from WARBL. R4 max value reached
+    /* MrMep: I think there's an error in the Google Doc: 22 there is unused, but these values must be continous 
+    * see Functions.ino line 1600
+    */
+    const MIDI_CC_102_VALUE_22 = 22; //from WARBL. R3 max value reached	
+    const MIDI_CC_102_VALUE_23 = 23; //from WARBL. R2 max value reached	
+    const MIDI_CC_102_VALUE_24 = 24; //from WARBL. R1 max value reached
+    const MIDI_CC_102_VALUE_25 = 25; //from WARBL. L3 max value reached
+    const MIDI_CC_102_VALUE_26 = 26; //from WARBL. L2 max value reached
+    const MIDI_CC_102_VALUE_27 = 27; //from WARBL. L1 max value reached
+    const MIDI_CC_102_VALUE_28 = 28; //from WARBL. Lthumb max value reached
+; //
+    /* 29 unused ? */
+; //Send fingering pattern selections:
+    const MIDI_CC_102_VALUE_30 = 30; // Bidirectional. indicates that the next command will be the fingering pattern for instrument 1
+    const MIDI_CC_102_VALUE_31 = 31; // Bidirectional. indicates that the next command will be the fingering pattern for instrument 2
+    const MIDI_CC_102_VALUE_32 = 32; // Bidirectional. indicates that the next command will be the fingering pattern for instrument 3
+    const MIDI_CC_102_VALUE_33 = 33; // Bidirectional. first fingering pattern is tin whistle
+    const MIDI_CC_102_VALUE_34 = 34; // Bidirectional. "" uilleann
+    const MIDI_CC_102_VALUE_35 = 35; // Bidirectional. “” GHB
+    const MIDI_CC_102_VALUE_36 = 36; // Bidirectional. “” Northumbrian
+    const MIDI_CC_102_VALUE_37 = 37; // Bidirectional. ""tin whistle/flute chromatic
+    const MIDI_CC_102_VALUE_38 = 38; // Bidirectional. ""Gaita
+    /* 39 unused ? */
+    const MIDI_CC_102_VALUE_40 = 40; // Bidirectional. NAF
+    const MIDI_CC_102_VALUE_41 = 41; // Bidirectional. Kaval
+    const MIDI_CC_102_VALUE_42 = 42; // Bidirectional. recorder
+    const MIDI_CC_102_VALUE_43 = 43; // Bidirectional. Uilleann regulators
+    const MIDI_CC_102_VALUE_44 = 44; // Bidirectional. Uilleann standard
+    const MIDI_CC_102_VALUE_45 = 45; // Bidirectional. Xiao
+    const MIDI_CC_102_VALUE_46 = 46; // Bidirectional. Sax
+    const MIDI_CC_102_VALUE_47 = 47; // Bidirectional. Gaita extended
+    /* 48-49 unused ? */
+    const MIDI_CC_102_VALUE_50 = 50; // Bidirectional. Saxbasic
+    const MIDI_CC_102_VALUE_51 = 51; // Bidirectional. EVI
+    const MIDI_CC_102_VALUE_52 = 52; // Bidirectional. Shakuhachi
+    const MIDI_CC_102_VALUE_53 = 53; // Bidirectional. Sackpipa major
+    const MIDI_CC_102_VALUE_54 = 54; // Bidirectional. Sackpipa minor
+    const MIDI_CC_102_VALUE_55 = 55; // Bidirectional. Custom
+    const MIDI_CC_102_VALUE_56 = 56; // Bidirectional. Bombarde
+    const MIDI_CC_102_VALUE_57 = 57; // Bidirectional. Baroque flute
+    const MIDI_CC_102_VALUE_58 = 58; // Bidirectional. Medieval bagpipes
+    const MIDI_CC_102_VALUE_59 = 59; // Bidirectional. Bansuri
+; //
+
+    const MIDI_CC_102_VALUE_60 = 60; // Bidirectional. current instrument (mode variable) is 0
+    const MIDI_CC_102_VALUE_61 = 61; // Bidirectional. current instrument is 1
+    const MIDI_CC_102_VALUE_62 = 62; // Bidirectional. current instrument is 2
+    /* 63-69 unused */
+    const MIDI_CC_102_VALUE_70 = 70; // Bidirectional. Settings for current instrument: Pitchbend mode 0
+    const MIDI_CC_102_VALUE_71 = 71; // Bidirectional. Settings for current instrument: Pitchbend mode 1
+    const MIDI_CC_102_VALUE_72 = 72; // Bidirectional. Settings for current instrument: Pitchbend mode 2
+    const MIDI_CC_102_VALUE_73 = 73; // Bidirectional. Settings for current instrument: Pitchbend mode 3
+    /* 74-79 unused */
+    const MIDI_CC_102_VALUE_80 = 80; // Bidirectional. Settings for current instrument: Breath mode 0
+    const MIDI_CC_102_VALUE_81 = 81; // Bidirectional. Settings for current instrument: Breath mode 1
+    const MIDI_CC_102_VALUE_82 = 82; // Bidirectional. Settings for current instrument: Breath mode 2
+    const MIDI_CC_102_VALUE_83 = 83; // Bidirectional. Settings for current instrument: Breath mode 3
+    const MIDI_CC_102_VALUE_84 = 84; // Bidirectional. Settings for current instrument: Breath mode4
+    const MIDI_CC_102_VALUE_85 = 85; // Bidirectional. default instrument is 0 - (if Config Tool sends 85 to WARBL, WARBL sets current instrument as default)
+    const MIDI_CC_102_VALUE_86 = 86; // Bidirectional. default instrument is 1
+    const MIDI_CC_102_VALUE_87 = 87; // Bidirectional. default instrument is 2
+    /* 88-89 unused */
+
+    /* Populate button configuration for current instrument:	
+    * First indicate button combination to be populated:
+    */
+    const MIDI_CC_102_VALUE_90 = 90; // Bidirectional. Sending data for click 1 (dropdown row 0)
+    const MIDI_CC_102_VALUE_91 = 91; // Bidirectional. click 2
+    const MIDI_CC_102_VALUE_92 = 92; // Bidirectional. click 3
+    const MIDI_CC_102_VALUE_93 = 93; // Bidirectional. hold 2, click 1
+    const MIDI_CC_102_VALUE_94 = 94; // Bidirectional. hold 2, click 3
+    const MIDI_CC_102_VALUE_95 = 95; // Bidirectional. longpress 1
+    const MIDI_CC_102_VALUE_96 = 96; // Bidirectional. longpress 2
+    const MIDI_CC_102_VALUE_97 = 97; // Bidirectional. longpress 3
+    const MIDI_CC_102_VALUE_98 = 98; // unused
+    const MIDI_CC_102_VALUE_99 = 99; // unused (previously disconnect command)
+    /* Follow with data to populate indicated button combination:
+    * CC 106	values 100-127 (see below) 
+    * (was previously CC 102 100-111 but ran out of room here)
+    */
+
+
+    const MIDI_CC_102_VALUE_100 = 100; // Bidirectional. WARBL2 custom fingering chart 1
+    const MIDI_CC_102_VALUE_101 = 101; // Bidirectional. WARBL2 custom fingering chart 2
+    const MIDI_CC_102_VALUE_102 = 102; // Bidirectional. WARBL2 custom fingering chart 3
+    const MIDI_CC_102_VALUE_103 = 103; // Bidirectional. WARBL2 custom fingering chart 4
+    const MIDI_CC_102_VALUE_104 = 104; //from Config Tool. exit communication mode (previously 102 99)
+    /* 105-111	unused -- can be used for WARBL2 */
+    const MIDI_CC_102_VALUE_112 = 112; // Bidirectional. send midi note on/note off
+    const MIDI_CC_102_VALUE_113 = 113; // Bidirectional. Send midi CC
+    const MIDI_CC_102_VALUE_114 = 114; // Bidirectional. Send MIDI PC
+    const MIDI_CC_102_VALUE_115 = 115; // Bidirectional. Increase PC
+    const MIDI_CC_102_VALUE_116 = 116; // Bidirectional. Decrease PC
+    const MIDI_CC_102_VALUE_117 = 117; // Bidirectional. momentary off
+    const MIDI_CC_102_VALUE_118 = 118; // Bidirectional. momentary on
+    /* 119 unused */
+    const MIDI_CC_102_VALUE_120 = 120; //from WARBL. bell sensor disconnected	
+    const MIDI_CC_102_VALUE_121 = 121; //from WARBL. bell sensor connected	
+    /* 122 unused */
+    const MIDI_CC_102_VALUE_123 = 123; //from Config Tool. save as defaults for current mode
+    const MIDI_CC_102_VALUE_124 = 124; //from Config Tool. save as defaults for all instruments
+    const MIDI_CC_102_VALUE_125 = 125; //from Config Tool. restore factory settings
+    const MIDI_CC_102_VALUE_126 = 126; //from Config Tool. enter communication mode
+    // WARBL enters communication mode (until it is shut off or user clicks "Disconnect") and responds by sending settings for currently selected instrument.
+    const MIDI_CC_102_VALUE_127 = 127; //from Config Tool. begin autocalibration
+
+
+const MIDI_CC_103 = 103; // from WARBL & from Config Tool. Values 0-127	- Settings for current instrument: finger-sensing distance
+
+const MIDI_CC_104 = 104; // from WARBL & from Config Tool. Various values as follows:
+    /* 0 unused */
+
+    /* Bag/Breath advanced settings (pressureSelector[] variables*/
+    const MIDI_CC_104_VALUE_1 = 1; // Bidirectional. Settings for current instrument: indicates "bag threshold" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_2 = 2; // Bidirectional. Settings for current instrument: indicates "bag multiplier" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_3 = 3; // Bidirectional. Settings for current instrument: indicates "bag histeresis" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_4 = 4; // Bidirectional. unused. 
+    const MIDI_CC_104_VALUE_5 = 5; // Bidirectional. Settings for current instrument: indicates "bag jump time" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_6 = 6; // Bidirectional. Settings for current instrument: indicates "bag drop time" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_7 = 7; // Bidirectional. Settings for current instrument: indicates "breath threshold" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_8 = 8; // Bidirectional. Settings for current instrument: indicates "breath multiplier" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_9 = 9; // Bidirectional. Settings for current instrument: indicates "breath histeresis" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_10 = 10; // Bidirectional. Settings for current instrument: indicates "breath transient filter" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_11 = 11; // Bidirectional. Settings for current instrument: indicates "breath jump time" is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_12 = 12; // Bidirectional. Settings for current instrument: indicates "breath drop time" is about to be sent with CC 105.
+    /* Expression or drones variable (ED array) - see defines above */
+    const MIDI_CC_104_VALUE_13 = 13; // Bidirectional. Settings for current instrument: indicates ED[0] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_14 = 14; // Bidirectional. Settings for current instrument: indicates ED[1] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_15 = 15; // Bidirectional. Settings for current instrument: indicates ED[2] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_16 = 16; // Bidirectional. Settings for current instrument: indicates ED[3] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_17 = 17; // Bidirectional. Settings for current instrument: indicates ED[4] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_18 = 18; // Bidirectional. Settings for current instrument: indicates ED[5] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_19 = 19; // Bidirectional. Settings for current instrument: indicates ED[6] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_20 = 20; // Bidirectional. Settings for current instrument: indicates ED[7] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_21 = 21; // Bidirectional. Settings for current instrument: indicates ED[8] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_22 = 22; // Bidirectional. Settings for current instrument: indicates ED[9] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_23 = 23; // Bidirectional. Settings for current instrument: indicates ED[10] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_24 = 24; // Bidirectional. Settings for current instrument: indicates ED[11] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_25 = 25; // Bidirectional. Settings for current instrument: indicates ED[12]] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_26 = 26; // Bidirectional. Settings for current instrument: indicates ED[13] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_27 = 27; // Bidirectional. Settings for current instrument: indicates ED[14] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_28 = 28; // Bidirectional. Settings for current instrument: indicates ED[15] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_29 = 29; // Bidirectional. Settings for current instrument: indicates ED[16] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_30 = 30; // Bidirectional. Settings for current instrument: indicates ED[17] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_31 = 31; // Bidirectional. Settings for current instrument: indicates ED[18] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_32 = 32; // Bidirectional. Settings for current instrument: indicates ED[19] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_33 = 33; // Bidirectional. Settings for current instrument: indicates ED[20] is about to be sent with CC 105. 
+; //
+    /* MrMep: this could be wrong on the google Doc */
+    const MIDI_CC_104_VALUE_34 = 34; // Bidirectional. Settings for current instrument: indicates that lsb of learned note trigger pressure is about to be sent on CC 105
+    const MIDI_CC_104_VALUE_35 = 35; // Bidirectional. Settings for current instrument: indicates that msb of learned note trigger pressure is about to be sent on CC 105
+    /* 36-39 unused */
+
+    /* Switches array - see defines above */
+    const MIDI_CC_104_VALUE_40 = 40; // Bidirectional. Settings for current instrument: indicates that switches[0] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_41 = 41; // Bidirectional. Settings for current instrument: indicates that switches[1] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_42 = 42; // Bidirectional. Settings for current instrument: indicates that switches[2] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_43 = 43; // Bidirectional. Settings for current instrument: indicates that switches[3] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_44 = 44; // Bidirectional. Settings for current instrument: indicates that switches[4] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_45 = 45; // Bidirectional. Settings for current instrument: indicates that switches[5] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_46 = 46; // Bidirectional. Settings for current instrument: indicates that switches[6] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_47 = 47; // Bidirectional. Settings for current instrument: indicates that switches[7] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_48 = 48; // Bidirectional. Settings for current instrument: indicates that switches[8] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_49 = 49; // Bidirectional. Settings for current instrument: indicates that switches[9] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_50 = 50; // Bidirectional. Settings for current instrument: indicates that switches[10] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_51 = 51; // Bidirectional. Settings for current instrument: indicates that switches[11] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_52 = 52; // Bidirectional. Settings for current instrument: indicates that switches[12] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_53 = 53; // Bidirectional. Settings for current instrument: indicates that switches[13] is about to be sent with CC 105. UNUSED?
+; //
+    /* 54-60 unused */
+; //MrMep: The following 2 must be wrong on the google doc
+    const MIDI_CC_104_VALUE_61 = 61; // Bidirectional. Settings for current instrument: MIDI bend range is about to be sent on CC 105
+    const MIDI_CC_104_VALUE_62 = 62; // Bidirectional. Settings for current instrument: MIDI channel is about to be sent on CC 105
+    /* 62-69 unused */
+
+	/* more expression or drones variables (ED array) 
+    * can be extended to 127 for WARBL2, e.g. IMU functionality. If more variables are needed CC109 can also be used to indicate additional "pressureReceiveMode" options
+    */
+    const MIDI_CC_104_VALUE_70 = 70; // Bidirectional. Settings for current instrument: indicates ED[21] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_71 = 71; // Bidirectional. Settings for current instrument: indicates ED[22] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_72 = 72; // Bidirectional. Settings for current instrument: indicates ED[23] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_73 = 73; // Bidirectional. Settings for current instrument: indicates ED[24] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_74 = 74; // Bidirectional. Settings for current instrument: indicates ED[25] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_75 = 75; // Bidirectional. Settings for current instrument: indicates ED[26] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_76 = 76; // Bidirectional. Settings for current instrument: indicates ED[27] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_77 = 77; // Bidirectional. Settings for current instrument: indicates ED[28] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_78 = 78; // Bidirectional. Settings for current instrument: indicates ED[29] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_79 = 79; // Bidirectional. Settings for current instrument: indicates ED[30] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_80 = 80; // Bidirectional. Settings for current instrument: indicates ED[31] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_81 = 81; // Bidirectional. Settings for current instrument: indicates ED[32] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_82 = 82; // Bidirectional. Settings for current instrument: indicates ED[33] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_83 = 83; // Bidirectional. Settings for current instrument: indicates ED[34] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_84 = 84; // Bidirectional. Settings for current instrument: indicates ED[35] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_85 = 85; // Bidirectional. Settings for current instrument: indicates ED[36] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_86 = 86; // Bidirectional. Settings for current instrument: indicates ED[37] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_87 = 87; // Bidirectional. Settings for current instrument: indicates ED[38] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_88 = 88; // Bidirectional. Settings for current instrument: indicates ED[39] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_89 = 89; // Bidirectional. Settings for current instrument: indicates ED[40] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_90 = 90; // Bidirectional. Settings for current instrument: indicates ED[41] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_91 = 91; // Bidirectional. Settings for current instrument: indicates ED[42] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_92 = 92; // Bidirectional. Settings for current instrument: indicates ED[43] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_93 = 93; // Bidirectional. Settings for current instrument: indicates ED[44] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_94 = 94; // Bidirectional. Settings for current instrument: indicates ED[45] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_95 = 95; // Bidirectional. Settings for current instrument: indicates ED[46] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_96 = 96; // Bidirectional. Settings for current instrument: indicates ED[47] is about to be sent with CC 105. 
+    const MIDI_CC_104_VALUE_97 = 97; // Bidirectional. Settings for current instrument: indicates ED[48] is about to be sent with CC 105. 
+; //
+    /* 98-127 unused */
+
+const MIDI_CC_105 = 105; // Bidirectional - From Warbl. Values 0-127. Settings for current instrument: value of above variable indicated by CC 104 or variable indicated by CC 109 (see below)
+
+const MIDI_CC_106 = 106; // from WARBL & from Config Tool. Various values as follows:
+; //MIDI Channels
+    const MIDI_CC_106_VALUE_0 = 0; //Bidirectional. MIDI channel 1
+    const MIDI_CC_106_VALUE_1 = 1; //Bidirectional. MIDI channel 2
+    const MIDI_CC_106_VALUE_2 = 2; //Bidirectional. MIDI channel 3
+    const MIDI_CC_106_VALUE_3 = 3; //Bidirectional. MIDI channel 4
+    const MIDI_CC_106_VALUE_4 = 4; //Bidirectional. MIDI channel 5
+    const MIDI_CC_106_VALUE_5 = 5; //Bidirectional. MIDI channel 6
+    const MIDI_CC_106_VALUE_6 = 6; //Bidirectional. MIDI channel 7
+    const MIDI_CC_106_VALUE_7 = 7; //Bidirectional. MIDI channel 8
+    const MIDI_CC_106_VALUE_8 = 8; //Bidirectional. MIDI channel 9
+    const MIDI_CC_106_VALUE_9 = 9; //Bidirectional. MIDI channel 10
+    const MIDI_CC_106_VALUE_10 = 10; //Bidirectional. MIDI channel 11
+    const MIDI_CC_106_VALUE_11 = 11; //Bidirectional. MIDI channel 12
+    const MIDI_CC_106_VALUE_12 = 12; //Bidirectional. MIDI channel 13
+    const MIDI_CC_106_VALUE_13 = 13; //Bidirectional. MIDI channel 14
+    const MIDI_CC_106_VALUE_14 = 14; //Bidirectional. MIDI channel 15
+    const MIDI_CC_106_VALUE_15 = 15; //Bidirectional. MIDI channel 16
+; //
+    const MIDI_CC_106_VALUE_16 = 16; //Bidirectional. custom vibrato off
+    const MIDI_CC_106_VALUE_17 = 17; //Bidirectional. custom vibrato on
+    /* 18-19 unused */
+
+; //Vibrato holes
+    const MIDI_CC_106_VALUE_20 = 20; //Bidirectional. enable vibrato hole, 0	
+    const MIDI_CC_106_VALUE_21 = 21; //Bidirectional. enable vibrato hole, 1	
+    const MIDI_CC_106_VALUE_22 = 22; //Bidirectional. enable vibrato hole, 2	
+    const MIDI_CC_106_VALUE_23 = 23; //Bidirectional. enable vibrato hole, 3	
+    const MIDI_CC_106_VALUE_24 = 24; //Bidirectional. enable vibrato hole, 4	
+    const MIDI_CC_106_VALUE_25 = 25; //Bidirectional. enable vibrato hole, 5	
+    const MIDI_CC_106_VALUE_26 = 26; //Bidirectional. enable vibrato hole, 6	
+    const MIDI_CC_106_VALUE_27 = 27; //Bidirectional. enable vibrato hole, 7	
+    const MIDI_CC_106_VALUE_28 = 28; //Bidirectional. enable vibrato hole, 8	
+    /* 29 unused */
+    const MIDI_CC_106_VALUE_30 = 30; //Bidirectional. disable vibrato hole, 0
+    const MIDI_CC_106_VALUE_31 = 31; //Bidirectional. disable vibrato hole, 1
+    const MIDI_CC_106_VALUE_32 = 32; //Bidirectional. disable vibrato hole, 2
+    const MIDI_CC_106_VALUE_33 = 33; //Bidirectional. disable vibrato hole, 3
+    const MIDI_CC_106_VALUE_34 = 34; //Bidirectional. disable vibrato hole, 4
+    const MIDI_CC_106_VALUE_35 = 35; //Bidirectional. disable vibrato hole, 5
+    const MIDI_CC_106_VALUE_36 = 36; //Bidirectional. disable vibrato hole, 6
+    const MIDI_CC_106_VALUE_37 = 37; //Bidirectional. disable vibrato hole, 7
+    const MIDI_CC_106_VALUE_38 = 38; //Bidirectional. disable vibrato hole, 8
+; //
+    const MIDI_CC_106_VALUE_39 = 39; //Bidirectional. calibrate at startup
+    const MIDI_CC_106_VALUE_40 = 40; //Bidirectional. use learned calibration
+    const MIDI_CC_106_VALUE_41 = 41; // from Config Tool. learn initial note on pressure
+    const MIDI_CC_106_VALUE_42 = 42; // from Config Tool. autocalibrate bell sensor only	
+    const MIDI_CC_106_VALUE_43 = 43; // from Config Tool. learn drones on pressure
+    /* 44 unused */
+    const MIDI_CC_106_VALUE_45 = 45; // from Config Tool. save current sensor calibration as factory calibration (this is on a special webpage for me to use when I first program WARBL)
+    const MIDI_CC_106_VALUE_46 = 46; //Bidirectional.invert off
+    const MIDI_CC_106_VALUE_47 = 47; //Bidirectional.invert on
+	const MIDI_CC_106_VALUE_48 = 48; //from WARBL. next message will be byte 1 of debug message
+	const MIDI_CC_106_VALUE_49 = 49; //from WARBL. next message will be byte 2 of debug message
+	const MIDI_CC_106_VALUE_50 = 50; //from WARBL. next message will be byte 3 of debug message (midi requires three bytes to send/receive an int because MIDI bytes are actually only 7 bits)
+	const MIDI_CC_106_VALUE_51 = 51; //from WARBL. Indicates end of two-byte message 
+	const MIDI_CC_106_VALUE_52 = 52; //from WARBL. Indicates end of three-byte message 
+	const MIDI_CC_106_VALUE_53 = 53; //Bidirectional. Used to tell the Config Tool to include the uilleann regulators fingering pattern (used in a custom version of the code)	
+    const MIDI_CC_106_VALUE_54 = 54; //from Config Tool. WARBL2 calibrate IMU
+    const MIDI_CC_106_VALUE_55 = 55; //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+    const MIDI_CC_106_VALUE_56 = 56; //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+    const MIDI_CC_106_VALUE_57 = 57; //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+    /* 58-59 unused */
+    const MIDI_CC_106_VALUE_60 = 60; // from Config Tool. WARBL2 recenter yaw
+    /* 61-69 unused */
+    const MIDI_CC_106_VALUE_70 = 70; //from WARBL. WARBL2 battery voltage
+	const MIDI_CC_106_VALUE_71 = 71; //from WARBL. WARBL2 charging status
+
+; //MrMep: LSB and MSB are inverted in the Google Doc
+	const MIDI_CC_106_VALUE_72 = 72; //from WARBL. WARBL2 BLE connection interval low byte
+	const MIDI_CC_106_VALUE_73 = 73; //from WARBL. WARBL2 BLE connection interval high byte
+	const MIDI_CC_106_VALUE_74 = 74; //from WARBL. WARBL2 battery percentage
+    /* 75-99	unused -- can be used for WARBL2 */
+
+; //Button Actions, see above 102 90/00
+	const MIDI_CC_106_VALUE_100 = 100; //Bidirectional. button action 0 
+	const MIDI_CC_106_VALUE_101 = 101; //Bidirectional. button action 1
+	const MIDI_CC_106_VALUE_102 = 102; //Bidirectional. button action 2 
+	const MIDI_CC_106_VALUE_103 = 103; //Bidirectional. button action 3 
+	const MIDI_CC_106_VALUE_104 = 104; //Bidirectional. button action 4 
+	const MIDI_CC_106_VALUE_105 = 105; //Bidirectional. button action 5 
+	const MIDI_CC_106_VALUE_106 = 106; //Bidirectional. button action 6 
+	const MIDI_CC_106_VALUE_107 = 107; //Bidirectional. button action 7 
+	const MIDI_CC_106_VALUE_108 = 108; //Bidirectional. button action 8 
+	const MIDI_CC_106_VALUE_109 = 109; //Bidirectional. button action 9 
+	const MIDI_CC_106_VALUE_110 = 110; //Bidirectional. button action 10 
+	const MIDI_CC_106_VALUE_111 = 111; //Bidirectional. button action 11
+	const MIDI_CC_106_VALUE_112 = 112; //Bidirectional. button action 12
+	const MIDI_CC_106_VALUE_113 = 113; //Bidirectional. button action 13
+	const MIDI_CC_106_VALUE_114 = 114; //Bidirectional. button action 14
+	const MIDI_CC_106_VALUE_115 = 115; //Bidirectional. button action 15
+	const MIDI_CC_106_VALUE_116 = 116; //Bidirectional. button action 16
+	const MIDI_CC_106_VALUE_117 = 117; //Bidirectional. button action 17
+	const MIDI_CC_106_VALUE_118 = 118; //Bidirectional. button action 18
+	const MIDI_CC_106_VALUE_119 = 119; //Bidirectional. button action 19
+	const MIDI_CC_106_VALUE_120 = 120; //Bidirectional. button action 20
+	const MIDI_CC_106_VALUE_121 = 121; //Bidirectional. button action 21
+	const MIDI_CC_106_VALUE_122 = 122; //Bidirectional. button action 22
+	const MIDI_CC_106_VALUE_123 = 123; //Bidirectional. button action 23
+	const MIDI_CC_106_VALUE_124 = 124; //Bidirectional. button action 24
+	const MIDI_CC_106_VALUE_125 = 125; //Bidirectional. button action 25
+	const MIDI_CC_106_VALUE_126 = 126; //Bidirectional. button action 26
+	const MIDI_CC_106_VALUE_127 = 127; //Bidirectional. button action 27
+; //
+
+const MIDI_CC_107 = 107; // From WARBL. Values 0-127	- MIDI byte 2
+const MIDI_CC_108 = 108; // From WARBL. Values 0-127	- MIDI byte 3
+
+const MIDI_CC_109 = 109; // From WARBL. Values as follows:
+    const MIDI_CC_109_OFFSET = 200; //Value added to received CC 109, to distinguish them from those from CC_104
+; //IMU Settings Array - see defines above
+    const MIDI_CC_109_VALUE_0 = 0; // Bidirectional. Settings for current instrument: indicates IMUsettings[0] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_1 = 1; // Bidirectional. Settings for current instrument: indicates IMUsettings[1] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_2 = 2; // Bidirectional. Settings for current instrument: indicates IMUsettings[2] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_3 = 3; // Bidirectional. Settings for current instrument: indicates IMUsettings[3] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_4 = 4; // Bidirectional. Settings for current instrument: indicates IMUsettings[4] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_5 = 5; // Bidirectional. Settings for current instrument: indicates IMUsettings[5] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_6 = 6; // Bidirectional. Settings for current instrument: indicates IMUsettings[6] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_7 = 7; // Bidirectional. Settings for current instrument: indicates IMUsettings[7] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_8 = 8; // Bidirectional. Settings for current instrument: indicates IMUsettings[8] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_9 = 9; // Bidirectional. Settings for current instrument: indicates IMUsettings[9] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_10 = 10; // Bidirectional. Settings for current instrument: indicates IMUsettings[10] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_11 = 11; // Bidirectional. Settings for current instrument: indicates IMUsettings[11] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_12 = 12; // Bidirectional. Settings for current instrument: indicates IMUsettings[12] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_13 = 13; // Bidirectional. Settings for current instrument: indicates IMUsettings[13] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_14 = 14; // Bidirectional. Settings for current instrument: indicates IMUsettings[14] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_15 = 15; // Bidirectional. Settings for current instrument: indicates IMUsettings[15] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_16 = 16; // Bidirectional. Settings for current instrument: indicates IMUsettings[16] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_17 = 17; // Bidirectional. Settings for current instrument: indicates IMUsettings[17] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_18 = 18; // Bidirectional. Settings for current instrument: indicates IMUsettings[18] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_19 = 19; // Bidirectional. Settings for current instrument: indicates IMUsettings[19] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_20 = 20; // Bidirectional. Settings for current instrument: indicates IMUsettings[20] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_21 = 21; // Bidirectional. Settings for current instrument: indicates IMUsettings[21] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_22 = 22; // Bidirectional. Settings for current instrument: indicates IMUsettings[22] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_23 = 23; // Bidirectional. Settings for current instrument: indicates IMUsettings[23] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_24 = 24; // Bidirectional. Settings for current instrument: indicates IMUsettings[24] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_25 = 25; // Bidirectional. Settings for current instrument: indicates IMUsettings[25] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_26 = 26; // Bidirectional. Settings for current instrument: indicates IMUsettings[26] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_27 = 27; // Bidirectional. Settings for current instrument: indicates IMUsettings[27] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_28 = 28; // Bidirectional. Settings for current instrument: indicates IMUsettings[28] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_29 = 29; // Bidirectional. Settings for current instrument: indicates IMUsettings[29] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_30 = 30; // Bidirectional. Settings for current instrument: indicates IMUsettings[30] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_31 = 31; // Bidirectional. Settings for current instrument: indicates IMUsettings[31] is about to be sent with CC 105. 
+    const MIDI_CC_109_VALUE_32 = 32; // Bidirectional. Settings for current instrument: indicates IMUsettings[32] is about to be sent with CC 105. 
+    /* 33-99	unused -- can be used to extend above array or for other variables */
+
+    const MIDI_CC_109_VALUE_100 = 100; // Bidirectional. Indicates that WARBL2 custom fingering chart 1 is about to be sent on CC 105. Same command from WARBL indicates that all 256 messages were received.
+    const MIDI_CC_109_VALUE_101 = 101; // Bidirectional. Indicates that WARBL2 custom fingering chart 2 is about to be sent on CC 105. 
+    const MIDI_CC_109_VALUE_102 = 102; // Bidirectional. Indicates that WARBL2 custom fingering chart 3 is about to be sent on CC 105. 
+    const MIDI_CC_109_VALUE_103 = 103; // Bidirectional. Indicates that WARBL2 custom fingering chart 4 is about to be sent on CC 105. 
+	/* 104-126	unused */
+    const MIDI_CC_109_VALUE_127 = 127; // From WARBL. Indicates button/gesture action will be sent on CC 105
+
+
+const MIDI_CC_110 = 110; // From WARBL. Values 0-127	- firmware version
+const MIDI_CC_111 = 111; // Bidirectional. Values 0-127	- note shift for mode 0
+    const MIDI_CC_111_VALUE_109 = 109; // Bidirectional. Hidden sticks mode - Same for 112 and 113
+const MIDI_CC_112 = 112; // Bidirectional. Values 0-127	- note shift for mode 1
+const MIDI_CC_113 = 113; // Bidirectional. Values 0-127	- note shift for mode 2
+
+const MIDI_CC_114 = 114; // From WARBL. Values 0-127	- highest 2 bytes of holeCovered (int indicating which holes are currently covered)
+const MIDI_CC_115 = 115; // From WARBL. Values 0-127	- lowest 7 bytes of holeCovered
+const MIDI_CC_116 = 116; // From WARBL. Values 0-127	- LSB of pressure
+const MIDI_CC_117 = 117; // Bidirectional. Values 0-100	- vibrato depth (cents)
+const MIDI_CC_118 = 118; // From WARBL. Values 0-127	- MSB of pressure
+const MIDI_CC_119 = 119; // From WARBL. Values 0-127	- value of above variable indicated by CC 106
+
+const MIDI_CC_123 = 123; // MIDI PANIC
+//END of MIDI Numerical constants
+
+//Human readable constants
+/* Commands - VALUES ONLY */
+const MIDI_SAVE_CALIB = MIDI_CC_102_VALUE_19; //from Config Tool. Save optical sensor calibration
+const MIDI_EXIT_COMM_MODE = MIDI_CC_102_VALUE_104; //from Config Tool. exit communication mode (previously 102 99)
+const MIDI_SAVE_AS_DEFAULTS_CURRENT = MIDI_CC_102_VALUE_123; //from Config Tool. save as defaults for current mode
+const MIDI_SAVE_AS_DEFAULTS_ALL = MIDI_CC_102_VALUE_124; //from Config Tool. save as defaults for all instruments
+const MIDI_RESTORE_FACTORY = MIDI_CC_102_VALUE_125; //from Config Tool. restore factory settings
+const MIDI_ENTER_COMM_MODE = MIDI_CC_102_VALUE_126; //from Config Tool. enter communication mode
+const MIDI_START_CALIB = MIDI_CC_102_VALUE_127; //from Config Tool. begin autocalibration
+
+const MIDI_LEARN_INITIAL_NOTE_PRESS = MIDI_CC_106_VALUE_41; // from Config Tool. learn initial note on pressure
+const MIDI_CALIB_BELL_SENSOR = MIDI_CC_106_VALUE_42; // from Config Tool. autocalibrate bell sensor only
+const MIDI_LEARN_DRONES_PRESSURE = MIDI_CC_106_VALUE_43; // from Config Tool. learn drones on pressure
+const MIDI_SAVE_CALIB_AS_FACTORY = MIDI_CC_106_VALUE_45; // from Config Tool. save current sensor calibration as factory calibration (this is on a special webpage for me to use when I first program WARBL)
+const MIDI_CALIB_IMU = MIDI_CC_106_VALUE_54; //from Config Tool. WARBL2 calibrate IMU
+const MIDI_CENTER_YAW = MIDI_CC_106_VALUE_60; // from Config Tool. WARBL2 recenter yaw
+
+const MIDI_STICKS_MODE = MIDI_CC_111_VALUE_109; // Bidirectional. Hidden sticks mode - Same for 112 and 113
+
+/* START - END Values */
+const MIDI_CALIB_MSGS_START = MIDI_CC_102_VALUE_1; // Start of Calibration correction messages
+const MIDI_CALIB_MSGS_END = MIDI_CC_102_VALUE_18; // End of Calibration correction messages
+const MIDI_MAX_CALIB_MSGS_START = MIDI_CC_102_VALUE_20; // Start of Calibration max values reached messages
+const MIDI_MAX_CALIB_MSGS_END = MIDI_CC_102_VALUE_28; // End of Calibration max values reached messages
+const MIDI_FINGERING_PATTERN_MODE_START = MIDI_CC_102_VALUE_30; // Bidirectional. indicates that the next command will be the fingering pattern for instrument 1
+const MIDI_FINGERING_PATTERN_START = MIDI_CC_102_VALUE_33; // Bidirectional. first fingering pattern is tin whistle
+const MIDI_FINGERING_PATTERN_END = MIDI_CC_102_VALUE_59; // Bidirectional. Bansuri
+const MIDI_CURRENT_MODE_START = MIDI_CC_102_VALUE_60; // Bidirectional. current instrument (mode variable) is 0
+const MIDI_PB_MODE_START = MIDI_CC_102_VALUE_70; // Bidirectional. Settings for current instrument: Pitchbend mode 0
+const MIDI_BREATH_MODE_START = MIDI_CC_102_VALUE_80; // Bidirectional. Settings for current instrument: Breath mode 0
+const MIDI_DEFAULT_MODE_START = MIDI_CC_102_VALUE_85; // Bidirectional. default instrument is 0 - (if Config Tool sends 85 to WARBL, WARBL sets current instrument as default)
+const MIDI_GESTURE_START = MIDI_CC_102_VALUE_90; // Bidirectional. Sending data for click 1 (dropdown row 0)
+const MIDI_CUST_FINGERING_PATTERN_START = MIDI_CC_102_VALUE_100; // Bidirectional. WARBL2 custom fingering chart 1
+const MIDI_CUST_FINGERING_PATTERN_END = MIDI_CC_102_VALUE_103; // Bidirectional. WARBL2 custom fingering chart 4
+const MIDI_ACTION_MIDI_START = MIDI_CC_102_VALUE_112; // Bidirectional. send midi note on/note off
+
+const MIDI_PRESS_SELECT_VARS_START = MIDI_CC_104_VALUE_1; // Bidirectional. Settings for current instrument: indicates ""bag threshold"" is about to be sent with CC 105.
+const MIDI_PRESS_SELECT_VARS_END = MIDI_CC_104_VALUE_12; // Bidirectional. Settings for current instrument: indicates "breath drop time" is about to be sent with CC 105.
+const MIDI_ED_VARS_START = MIDI_CC_104_VALUE_13; // Bidirectional. Settings for current instrument: indicates ED[0] is about to be sent with CC 105. 
+const MIDI_ED_VARS_END = MIDI_CC_104_VALUE_33; // Bidirectional. Settings for current instrument: indicates ED[20] is about to be sent with CC 105. 
+const MIDI_SWITCHES_VARS_START = MIDI_CC_104_VALUE_40; // Bidirectional. Settings for current instrument: indicates that switches[0] is about to be sent with CC 105. 
+const MIDI_SWITCHES_VARS_END = MIDI_CC_104_VALUE_53; // Bidirectional. Settings for current instrument: indicates that switches[13] is about to be sent with CC 105. UNUSED?
+const MIDI_ED_VARS2_START = MIDI_CC_104_VALUE_70; // Bidirectional. Settings for current instrument: indicates ED[21] is about to be sent with CC 105. 
+const MIDI_ED_VARS2_END = MIDI_CC_104_VALUE_97; // Bidirectional. Settings for current instrument: indicates ED[48] is about to be sent with CC 105. 
+const MIDI_ED_VARS_NUMBER = MIDI_ED_VARS_END - MIDI_ED_VARS_START + 1; //ED array number of vars for the first slot
+const MIDI_ED_VARS2_OFFSET = MIDI_ED_VARS2_START - MIDI_ED_VARS_NUMBER; //ED array index for 2nd slot of MIDI Msgs
+
+const MIDI_ACTION_MIDI_CHANNEL_END = MIDI_CC_106_VALUE_15; //Bidirectional. MIDI channel 16
+
+const MIDI_ENA_VIBRATO_HOLES_START = MIDI_CC_106_VALUE_20; //Bidirectional. enable vibrato hole, 0	
+const MIDI_ENA_VIBRATO_HOLES_END = MIDI_CC_106_VALUE_28; //Bidirectional. enable vibrato hole, 8	
+const MIDI_DIS_VIBRATO_HOLES_START = MIDI_CC_106_VALUE_30; //Bidirectional. disable vibrato hole, 0	
+const MIDI_DIS_VIBRATO_HOLES_END = MIDI_CC_106_VALUE_38; //Bidirectional. disable vibrato hole, 8	
+const MIDI_WARBL2_SETTINGS_START = MIDI_CC_106_VALUE_55; //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+const MIDI_WARBL2_SETTINGS_END = MIDI_CC_106_VALUE_74; //Bidirectional. WARBL2 settings array (for settings that are independent of mode)
+const MIDI_BUTTON_ACTIONS_START = MIDI_CC_106_VALUE_100; //Bidirectional. button action 0 
+
+const MIDI_CUSTOM_CHARTS_START = MIDI_CC_109_VALUE_100; //Beginning of WARBL2 CustomCharts
+const MIDI_CUSTOM_CHARTS_END = MIDI_CC_109_VALUE_103; //End of WARBL2 CustomCharts
+const MIDI_CUSTOM_CHARTS_OFFSET_START = MIDI_CC_109_OFFSET + MIDI_CUSTOM_CHARTS_START; //Beginning of WARBL2 CustomCharts
+const MIDI_CUSTOM_CHARTS_OFFSET_END = MIDI_CC_109_OFFSET + MIDI_CUSTOM_CHARTS_END; //End of WARBL2 CustomCharts
+
+/* Various single Values */
+const MIDI_MOMENTARY_OFF = MIDI_CC_102_VALUE_117; // Bidirectional. momentary off
+const MIDI_MOMENTARY_ON = MIDI_CC_102_VALUE_118; // Bidirectional. momentary on
+
+const MIDI_LEARNED_PRESS_LSB = MIDI_CC_104_VALUE_34; // Bidirectional. Settings for current instrument: indicates that lsb of learned note trigger pressure is about to be sent on CC 105
+const MIDI_LEARNED_PRESS_MSB = MIDI_CC_104_VALUE_35; // Bidirectional. Settings for current instrument: indicates that msb of learned note trigger pressure is about to be sent on CC 105
+const MIDI_BEND_RANGE = MIDI_CC_104_VALUE_61; // Bidirectional. Settings for current instrument: MIDI bend range is about to be sent on CC 105
+const MIDI_MIDI_CHANNEL = MIDI_CC_104_VALUE_62; // Bidirectional. Settings for current instrument: MIDI channel is about to be sent on CC 105
+
+const MIDI_STARTUP_CALIB = MIDI_CC_106_VALUE_39; //Bidirectional. calibrate at startup
+const MIDI_USE_LEARNED_CALIB = MIDI_CC_106_VALUE_40; //Bidirectional. use learned calibration
+const MIDI_BLE_INTERVAL_LSB = MIDI_CC_106_VALUE_72; //from WARBL. WARBL2 BLE connection interval low byte
+const MIDI_BLE_INTERVAL_MSB = MIDI_CC_106_VALUE_73; //from WARBL. WARBL2 BLE connection interval high byte
+
+//END of Human readable constants
+//END of constants To Be Sync'd with Defines.h in firmware
+
+
+/* Config tool only Constants */
+const MIDI_IMU_SETTINGS_START =  MIDI_CC_109_VALUE_0; // Bidirectional. Settings for current instrument: indicates IMUsettings[0] is about to be sent with CC 105. 
+const MIDI_IMU_SETTINGS_END =  MIDI_CC_109_VALUE_32; // Bidirectional. Settings for current instrument: indicates IMUsettings[32] is about to be sent with CC 105. 
+
+const MIDI_CUSTOM_CHARTS_RCVD = MIDI_CC_109_VALUE_100 ////from WARBL. WARBL2 Custom fingering charts - indicate success
+const MIDI_EXPRESSION_DEPTH = MIDI_CC_104_VALUE_14; // Bidirectional. Settings for current instrument: indicates ED[1] is about to be sent with CC 105. 
+const MIDI_SEND_PRESSURE = MIDI_CC_104_VALUE_15; // Bidirectional. Settings for current instrument: indicates ED[2] is about to be sent with CC 105. 
+const MIDI_CURVE = MIDI_CC_104_VALUE_16; // Bidirectional. Settings for current instrument: indicates ED[3] is about to be sent with CC 105. 
+const MIDI_PRESSURE_CHANNEL = MIDI_CC_104_VALUE_17; // Bidirectional. Settings for current instrument: indicates ED[4] is about to be sent with CC 105. 
+const MIDI_PRESSURE_CC = MIDI_CC_104_VALUE_18; // Bidirectional. Settings for current instrument: indicates ED[5] is about to be sent with CC 105. 
+const MIDI_INPUT_PRESSURE_MIN = MIDI_CC_104_VALUE_19; // Bidirectional. Settings for current instrument: indicates ED[6] is about to be sent with CC 105. 
+const MIDI_INPUT_PRESSURE_MAX = MIDI_CC_104_VALUE_20; // Bidirectional. Settings for current instrument: indicates ED[7] is about to be sent with CC 105. 
+const MIDI_OUTPUT_PRESSURE_MIN = MIDI_CC_104_VALUE_21; // Bidirectional. Settings for current instrument: indicates ED[8] is about to be sent with CC 105. 
+const MIDI_OUTPUT_PRESSURE_MAX = MIDI_CC_104_VALUE_22; // Bidirectional. Settings for current instrument: indicates ED[9] is about to be sent with CC 105. 
+const MIDI_DRONES_ON_COMMAND = MIDI_CC_104_VALUE_23; // Bidirectional. Settings for current instrument: indicates ED[10] is about to be sent with CC 105. 
+const MIDI_DRONES_ON_CHANNEL = MIDI_CC_104_VALUE_24; // Bidirectional. Settings for current instrument: indicates ED[11] is about to be sent with CC 105. 
+const MIDI_DRONES_ON_BYTE2 = MIDI_CC_104_VALUE_25; // Bidirectional. Settings for current instrument: indicates ED[12] is about to be sent with CC 105. 
+const MIDI_DRONES_ON_BYTE3 = MIDI_CC_104_VALUE_26; // Bidirectional. Settings for current instrument: indicates ED[13] is about to be sent with CC 105. 
+const MIDI_DRONES_OFF_COMMAND = MIDI_CC_104_VALUE_27; // Bidirectional. Settings for current instrument: indicates ED[14] is about to be sent with CC 105. 
+const MIDI_DRONES_OFF_CHANNEL = MIDI_CC_104_VALUE_28; // Bidirectional. Settings for current instrument: indicates ED[15] is about to be sent with CC 105. 
+const MIDI_DRONES_OFF_BYTE2 = MIDI_CC_104_VALUE_29; // Bidirectional. Settings for current instrument: indicates ED[16] is about to be sent with CC 105. 
+const MIDI_DRONES_OFF_BYTE3 = MIDI_CC_104_VALUE_30; // Bidirectional. Settings for current instrument: indicates ED[17] is about to be sent with CC 105. 
+const MIDI_DRONES_CONTROL_MODE = MIDI_CC_104_VALUE_31; // Bidirectional. Settings for current instrument: indicates ED[18] is about to be sent with CC 105. 
+const MIDI_DRONES_PRESSURE_LOW_BYTE = MIDI_CC_104_VALUE_32; // Bidirectional. Settings for current instrument: indicates ED[19] is about to be sent with CC 105. 
+const MIDI_DRONES_PRESSURE_HIGH_BYTE = MIDI_CC_104_VALUE_33; // Bidirectional. Settings for current instrument: indicates ED[20] is about to be sent with CC 105. 
+const MIDI_VELOCITY_CURVE = MIDI_CC_104_VALUE_82; // Bidirectional. Settings for current instrument: indicates ED[33] is about to be sent with CC 105. 
+const MIDI_EXPRESSION_MIN = MIDI_CC_104_VALUE_85; // Bidirectional. Settings for current instrument: indicates ED[36] is about to be sent with CC 105. 
+const MIDI_EXPRESSION_MAX = MIDI_CC_104_VALUE_86; // Bidirectional. Settings for current instrument: indicates ED[37] is about to be sent with CC 105. 
+
+const MIDI_SLIDE_LIMIT_MAX = MIDI_CC_104_VALUE_87; // Bidirectional. Settings for current instrument: indicates ED[38] is about to be sent with CC 105. 
+
+const MIDI_SEND_ROLL = MIDI_CC_109_VALUE_0; // Bidirectional. Settings for current instrument: indicates IMUsettings[0] is about to be sent with CC 105. 
+const MIDI_SEND_PITCH = MIDI_CC_109_VALUE_1; // Bidirectional. Settings for current instrument: indicates IMUsettings[1] is about to be sent with CC 105. 
+const MIDI_SEND_YAW = MIDI_CC_109_VALUE_2; // Bidirectional. Settings for current instrument: indicates IMUsettings[2] is about to be sent with CC 105. 
+const MIDI_SEND_CENTER_ROLL = MIDI_CC_109_VALUE_3; // Bidirectional. Settings for current instrument: indicates IMUsettings[3] is about to be sent with CC 105. 
+const MIDI_SEND_CENTER_YAW = MIDI_CC_109_VALUE_4; // Bidirectional. Settings for current instrument: indicates IMUsettings[4] is about to be sent with CC 105. 
+
+const MIDI_IMU_CHANNEL_START = MIDI_CC_109_VALUE_17; // Bidirectional. Settings for current instrument: indicates IMUsettings[17] is about to be sent with CC 105. 
+const MIDI_IMU_CC_START = MIDI_CC_109_VALUE_19; // Bidirectional. Settings for current instrument: indicates IMUsettings[19] is about to be sent with CC 105. 
+
+const MIDI_AUTOCENTER_YAW = MIDI_CC_109_VALUE_23; // Bidirectional. Settings for current instrument: indicates IMUsettings[23] is about to be sent with CC 105. 
+const MIDI_Y_SHAKE_PITCHBEND = MIDI_CC_109_VALUE_24; // Bidirectional. Settings for current instrument: indicates IMUsettings[24] is about to be sent with CC 105. 
+const MIDI_AUTOCENTER_YAW_INTERVAL = MIDI_CC_109_VALUE_25; // Bidirectional. Settings for current instrument: indicates IMUsettings[25] is about to be sent with CC 105. 
+const MIDI_PITCH_REGISTER = MIDI_CC_109_VALUE_26; // Bidirectional. Settings for current instrument: indicates IMUsettings[26] is about to be sent with CC 105. 
+const MIDI_Y_PITCHBEND_DEPTH = MIDI_CC_109_VALUE_27; // Bidirectional. Settings for current instrument: indicates IMUsettings[27] is about to be sent with CC 105. 
+const MIDI_PITCH_REGISTER_INPUT_MIN = MIDI_CC_109_VALUE_28; // Bidirectional. Settings for current instrument: indicates IMUsettings[28] is about to be sent with CC 105. 
+const MIDI_PITCH_REGISTER_INPUT_MAX = MIDI_CC_109_VALUE_29; // Bidirectional. Settings for current instrument: indicates IMUsettings[29] is about to be sent with CC 105. 
+
+const MIDI_PITCH_REGISTER_NUMBER = MIDI_CC_109_VALUE_30; // Bidirectional. Settings for current instrument: indicates IMUsettings[30] is about to be sent with CC 105. 
+const MIDI_Y_PITCHBEND_MODE = MIDI_CC_109_VALUE_31; // Bidirectional. Settings for current instrument: indicates IMUsettings[31] is about to be sent with CC 105. 
+
+
+//END Config tool only Constants
+
+
+/* END of MIDI Config Tool Constants */
+

--- a/webconfig/js/midi.js
+++ b/webconfig/js/midi.js
@@ -374,12 +374,12 @@ function buildMessage(byte2, byte3) {
 
 
 
-    if (!(byte2 == 102 && byte3 == 127) && !(byte2 == 106 && byte3 == 42)) {
+    if (!(byte2 == MIDI_CC_102 && byte3 == MIDI_START_CALIB) && !(byte2 == MIDI_CC_106 && byte3 == MIDI_CALIB_BELL_SENSOR)) {
         blink(1);
     } //blink once if we aren't doing autocalibration, which requires the LED to be on longer.
 
-    if (byte2 == 102) {
-        if (byte3 == 19) { //send message to save sensor calibration
+    if (byte2 == MIDI_CC_102) {
+        if (byte3 == MIDI_SAVE_CALIB) { //send message to save sensor calibration
             blink(3);
             for (var i = 1; i < 10; i++) {
                 document.getElementById("v" + (i)).innerHTML = "0";
@@ -389,12 +389,12 @@ function buildMessage(byte2, byte3) {
             }
         }
 
-        if (isEven(byte3) && byte3 < 19) { //send sensor calibration values
+        if (isEven(byte3) && byte3 <= MIDI_CALIB_MSGS_END) { //send sensor calibration values
             sensorValue[byte3 - 2]++;
             document.getElementById("v" + (byte3 >> 1)).innerHTML = sensorValue[byte3 - 2];
         }
 
-        if (isOdd(byte3) && byte3 < 19) {
+        if (isOdd(byte3) && byte3 <= MIDI_CALIB_MSGS_END) {
             sensorValue[byte3 - 1]--;
             document.getElementById("v" + ((byte3 + 1) >> 1)).innerHTML = sensorValue[byte3 - 1];
             checkMax((byte3 + 1) >> 1);
@@ -519,7 +519,7 @@ function WARBL_Receive(event) {
 
     // If we haven't established the WARBL output port and we get a received CC110 message on channel 7 (the first message that the WARBL sends back when connecting)
     // find the port by name by walking the output ports and matching the input port name
-    if ((!WARBLout) && ((data0 & 0x0F) == 6) && ((data0 & 0xf0) == 176) && (data1 == 110)) {
+    if ((!WARBLout) && ((data0 & 0x0F) == 6) && ((data0 & 0xf0) == 176) && (data1 == MIDI_CC_110)) {
         //alert(data0 & 0x0F);
 		
 
@@ -746,7 +746,7 @@ function WARBL_Receive(event) {
 
                 //setPing(); //start checking to make sure WARBL is still connected
 
-                if (data1 == 115) { //hole covered info from WARBL
+                if (data1 == MIDI_CC_115) { //hole covered info from WARBL
 
                     var byteA = data2;
                     for (var m = 0; m < 7; m++) {
@@ -764,7 +764,7 @@ function WARBL_Receive(event) {
                     }
                 }
 
-                if (data1 == 114) { //hole covered info from WARBL
+                if (data1 == MIDI_CC_114) { //hole covered info from WARBL
                     for (var n = 0; n < 2; n++) {
                         var byteB = data2;
                         if (bit_test(byteB, n) == 1) {
@@ -778,27 +778,27 @@ function WARBL_Receive(event) {
                             }
                         }
                     }
-                } else if (data1 == 102) { //parse based on received CC
-                    if (data2 > 19 && data2 < 30) {
-                        document.getElementById("v" + (data2 - 19)).innerHTML = "MAX"; //set sensor value field to max if message is received from WARBL
-                        checkMax((data2 - 19));
+                } else if (data1 == MIDI_CC_102) { //parse based on received CC
+                    if (data2 >= MIDI_MAX_CALIB_MSGS_START && data2 <= MIDI_MAX_CALIB_MSGS_END) {
+                        document.getElementById("v" + (data2 - MIDI_MAX_CALIB_MSGS_START -1)).innerHTML = "MAX"; //set sensor value field to max if message is received from WARBL
+                        checkMax((data2 - MIDI_MAX_CALIB_MSGS_START -1));
                     }
 
                     for (var i = 0; i < 3; i++) { // update the three selected fingering patterns if prompted by the tool.
-                        if (data2 == 30 + i) {
+                        if (data2 == MIDI_FINGERING_PATTERN_MODE_START + i) {
                             fingeringWrite = i;
                         }
 
-                        if ((data2 > 32 && data2 < 60)) {
+                        if ((data2 >= MIDI_FINGERING_PATTERN_START && data2 <= MIDI_FINGERING_PATTERN_END)) {
                             if (fingeringWrite == i) {
-                                document.getElementById("fingeringSelect" + i).value = data2 - 33;
+                                document.getElementById("fingeringSelect" + i).value = data2 - MIDI_FINGERING_PATTERN_START;
                             }
                             updateCells(); //update any dependant fields	
                         }
 						
-						if((data2 > 99 && data2 < 104) && version > 3.9){
+						if((data2 >= MIDI_CUST_FINGERING_PATTERN_START && data2 <= MIDI_CUST_FINGERING_PATTERN_END) && version > 3.9){
 							if (fingeringWrite == i) {
-                                document.getElementById("fingeringSelect" + i).value = data2 - 33;
+                                document.getElementById("fingeringSelect" + i).value = data2 - MIDI_FINGERING_PATTERN_START;
                             }
                             updateCells(); //update any dependant fields	
                         }
@@ -807,7 +807,7 @@ function WARBL_Receive(event) {
 
 
 
-                    if (data2 == 60) {
+                    if (data2 == MIDI_CURRENT_MODE_START) {
                         document.getElementById("fingering0").checked = true;
                         instrument = 0;
                         document.getElementById("instrument0").style.display = "block";
@@ -829,7 +829,7 @@ function WARBL_Receive(event) {
                         handleDefault();
                         customFingeringOkay();
                     }
-                    if (data2 == 61) {
+                    if (data2 == MIDI_CURRENT_MODE_START +1) {
                         document.getElementById("fingering1").checked = true;
                         instrument = 1;
                         document.getElementById("instrument0").style.display = "none";
@@ -851,7 +851,7 @@ function WARBL_Receive(event) {
                         handleDefault();
                         customFingeringOkay();
                     }
-                    if (data2 == 62) {
+                    if (data2 == MIDI_CURRENT_MODE_START +2) {
                         document.getElementById("fingering2").checked = true;
                         instrument = 2;
                         document.getElementById("instrument0").style.display = "none";
@@ -874,70 +874,91 @@ function WARBL_Receive(event) {
                         customFingeringOkay();
                     }
 
-
-                    if (data2 == 85) { //receive and handle default instrument settings
-                        defaultInstr = 0;
-                        handleDefault();
-                    }
-                    if (data2 == 86) {
-                        defaultInstr = 1;
-                        handleDefault();
-                    }
-                    if (data2 == 87) {
-                        defaultInstr = 2;
-                        handleDefault();
-                    }
-
-                    if (data2 == 70) {
-                        document.getElementById("pitchbendradio0").checked = true;
-                        updateCustom();
-                        updateCustom();
-                    }
-                    if (data2 == 71) {
-                        document.getElementById("pitchbendradio1").checked = true;
-                        updateCustom();
-                        updateCustom();
-                    }
-                    if (data2 == 72) {
-                        document.getElementById("pitchbendradio2").checked = true;
-                        updateCustom();
-                        updateCustom();
-                    }
-                    if (data2 == 73) {
-                        document.getElementById("pitchbendradio3").checked = true;
-                        updateCustom();
-                        updateCustom();
+                    // if (data2 == MIDI_DEFAULT_MODE_START) { //receive and handle default instrument settings
+                    //     defaultInstr = 0;
+                    //     handleDefault();
+                    // }
+                    // if (data2 == MIDI_DEFAULT_MODE_START +1) {
+                    //     defaultInstr = 1;
+                    //     handleDefault();
+                    // }
+                    // if (data2 == MIDI_DEFAULT_MODE_START+2) {
+                    //     defaultInstr = 2;
+                    //     handleDefault();
+                    // }
+                    for (var i = 0; i < 3; i++)  { //receive and handle default instrument settings
+                        if (data2 == MIDI_DEFAULT_MODE_START +i) {
+                            defaultInstr = i;
+                            handleDefault();
+                        }
                     }
 
-                    if (data2 == 80) {
-                        document.getElementById("sensorradio0").checked = true;
-                    }
-                    if (data2 == 81) {
-                        document.getElementById("sensorradio1").checked = true;
-                    }
-                    if (data2 == 82) {
-                        document.getElementById("sensorradio2").checked = true;
-                    }
-                    if (data2 == 83) {
-                        document.getElementById("sensorradio3").checked = true;
+                    // if (data2 == MIDI_PB_MODE_START) {
+                    //     document.getElementById("pitchbendradio0").checked = true;
+                    //     updateCustom();
+                    //     updateCustom();
+                    // }
+                    // if (data2 == 71) {
+                    //     document.getElementById("pitchbendradio1").checked = true;
+                    //     updateCustom();
+                    //     updateCustom();
+                    // }
+                    // if (data2 == 72) {
+                    //     document.getElementById("pitchbendradio2").checked = true;
+                    //     updateCustom();
+                    //     updateCustom();
+                    // }
+                    // if (data2 == 73) {
+                    //     document.getElementById("pitchbendradio3").checked = true;
+                    //     updateCustom();
+                    //     updateCustom();
+                    // }
+                    for (var i = 0; i < 4; i++)  { //receive and handle Pitchbend mode
+                        if (data2 == MIDI_PB_MODE_START +i) {
+                            document.getElementById("pitchbendradio" + i.toString()).checked = true;
+                            updateCustom();
+                            updateCustom();    
+                        }
                     }
 
-                    if (data2 == 121) {
+
+                    // if (data2 == 80) {
+                    //     document.getElementById("sensorradio0").checked = true;
+                    // }
+                    // if (data2 == 81) {
+                    //     document.getElementById("sensorradio1").checked = true;
+                    // }
+                    // if (data2 == 82) {
+                    //     document.getElementById("sensorradio2").checked = true;
+                    // }
+                    // if (data2 == 83) {
+                    //     document.getElementById("sensorradio3").checked = true;
+                    // }
+                    for (var i = 0; i < 4; i++)  { //receive and handle Breath mode
+                        if (data2 == MIDI_BREATH_MODE_START +i) {
+                            document.getElementById("sensorradio" + i.toString()).checked = true;
+
+                        }
+                    }
+
+
+                    if (data2 == MIDI_CC_102_VALUE_121) { //bell sensor connected	
                         document.getElementById("bellSensor").style.opacity = 1;
                         document.getElementById("1").disabled = false;
                         document.getElementById("2").disabled = false;
                         document.getElementById("v1").classList.add("sensorValueEnabled");
 
                     }
-                    if (data2 == 120) {
+                    if (data2 == MIDI_CC_102_VALUE_120) { //bell sensor disconnected	
                         document.getElementById("bellSensor").style.opacity = 0.1;
                         document.getElementById("1").disabled = true;
                         document.getElementById("2").disabled = true;
                         document.getElementById("v1").classList.remove("sensorValueEnabled");
                     }
 
+
                     for (var i = 0; i < numberOfGestures; i++) { //update button configuration	   
-                        if (data2 == 90 + i) {
+                        if (data2 == MIDI_GESTURE_START + i) {
                             buttonRowWrite = i;
 							//console.log(buttonRowWrite);
                         }
@@ -946,7 +967,7 @@ function WARBL_Receive(event) {
                     for (var j = 0; j < numberOfGestures; j++) { //update button configuration	
                         if (buttonRowWrite == j) {
 
-                            if (data2 == 119) { //special case for initiating autocalibration
+                            if (data2 == 119) { //special case for initiating autocalibration - NOT in WARBL2?
                                 document.getElementById("row" + (buttonRowWrite)).value = 19;
                             }
 
@@ -956,7 +977,7 @@ function WARBL_Receive(event) {
                                     document.getElementById("row" + (buttonRowWrite)).value = k;
                                 }
 
-                                if (k < 7 && data2 == 112 + k) {
+                                if (k < 7 && data2 == MIDI_ACTION_MIDI_START + k) {
                                     document.getElementById("MIDIrow" + (buttonRowWrite)).value = k;
                                     updateCells();
                                 }
@@ -967,379 +988,379 @@ function WARBL_Receive(event) {
 
                     for (var l = 0; l < 3; l++) { //update momentary switches
                         if (buttonRowWrite == l) {
-                            if (data2 == 117) {
+                            if (data2 == MIDI_MOMENTARY_OFF) {
                                 document.getElementById("checkbox" + l).checked = false;
                             }
-                            if (data2 == 118) {
+                            if (data2 == MIDI_MOMENTARY_ON) {
                                 document.getElementById("checkbox" + l).checked = true;
                             }
 
                         }
                     }
 
-                } else if (data1 == 103) {
+                } else if (data1 == MIDI_CC_103) {
                     document.getElementById("senseDistance").value = 0 - data2;
                 } //set sensedistance  
-                else if (data1 == 117) {
+                else if (data1 == MIDI_CC_117) {
                     document.getElementById("depth").value = data2 + 1;
                     var output = document.getElementById("demo14");
                     depth.dispatchEvent(new Event('input'));
                     output.innerHTML = data2 + 1;
                 } //set vibrato depth  
-                else if (data1 == 104) {
+                else if (data1 == MIDI_CC_104) {
                     jumpFactorWrite = data2;
                 } // so we know which pressure setting is going to be received.
-                else if (data1 == 109 && data2 != 100) {
-                    jumpFactorWrite = data2 + 200;
+                else if (data1 == MIDI_CC_109 && data2 != MIDI_CUSTOM_CHARTS_RCVD) {
+                    jumpFactorWrite = data2 + MIDI_CC_109_OFFSET;
                 } // so we know which WARBL2 IMU setting is going to be received.
-                else if (data1 == 109 && data2 == 100) { //Successful WARBL2 Custom chart receipt
+                else if (data1 == MIDI_CC_109 && data2 == MIDI_CUSTOM_CHARTS_RCVD) { //Successful WARBL2 Custom chart receipt
                     document.getElementById("sending").innerHTML = "Success!";
                     document.getElementById("WARBL2CustomSuccessOkay").style.display = "block";
                     document.getElementById('WARBL2customFingeringFill').value = '10';
                     document.getElementById("WARBL2CustomTextArea").value = '';
                 }
-                else if (data1 == 105 && jumpFactorWrite < 13) {
+                else if (data1 == MIDI_CC_105 && jumpFactorWrite <= MIDI_PRESS_SELECT_VARS_END) {
                     document.getElementById("jumpFactor" + jumpFactorWrite).value = data2;
-                    if (jumpFactorWrite == 10) {
+                    if (jumpFactorWrite == MIDI_CC_104_VALUE_10) {
                         document.getElementById("jumpFactor10b").value = data2; //special case for hysteresis			
                     }
-                    for (var i = 1; i < 13; i++) {
+                    for (var i = 1; i <= MIDI_PRESS_SELECT_VARS_END; i++) {
                         var k = document.getElementById("jumpFactor" + (i));
                         k.dispatchEvent(new Event('input'));
-                        if (i == 10) {
+                        if (i == MIDI_CC_104_VALUE_10) {
                             var k = document.getElementById("jumpFactor10b"); //special case for key delay slider
                             k.dispatchEvent(new Event('input'));
                         }
                     }
                 }
 
-                if (data1 == 105) {
+                if (data1 == MIDI_CC_105) {
 
-                    if (jumpFactorWrite == 13) {
+                    if (jumpFactorWrite == MIDI_ED_VARS_START) {
                         document.getElementById("checkbox6").checked = data2;
-                    } else if (jumpFactorWrite == 14) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +1) {
                         document.getElementById("expressionDepth").value = data2;
-                    } else if (jumpFactorWrite == 15) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +2) {
                         document.getElementById("checkbox7").checked = data2;
                         updateCustom();
-                    } else if (jumpFactorWrite == 16) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +3) {
                         curve[0] = data2;
-                    } else if (jumpFactorWrite == 17) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +4) {
                         document.getElementById("pressureChannel").value = data2;
-                    } else if (jumpFactorWrite == 18) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +5) {
                         document.getElementById("pressureCC").value = data2;
-                    } else if (jumpFactorWrite == 19) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +6) {
                         inputSliderMin[0] = data2;
                         slider.noUiSlider.set([data2, null]);
-                    } else if (jumpFactorWrite == 20) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +7) {
                         inputSliderMax[0] = data2;
                         slider.noUiSlider.set([null, data2]);
-                    } else if (jumpFactorWrite == 21) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +8) {
                         outputSliderMin[0] = data2;
                         slider2.noUiSlider.set([data2, null]);
-                    } else if (jumpFactorWrite == 22) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +9) {
                         outputSliderMax[0] = data2;
                         slider2.noUiSlider.set([null, data2]);
-                    } else if (jumpFactorWrite == 23) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +10) {
                         document.getElementById("dronesOnCommand").value = data2;
-                    } else if (jumpFactorWrite == 24) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +11) {
                         document.getElementById("dronesOnChannel").value = data2;
-                    } else if (jumpFactorWrite == 25) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +12) {
                         document.getElementById("dronesOnByte2").value = data2;
-                    } else if (jumpFactorWrite == 26) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +13) {
                         document.getElementById("dronesOnByte3").value = data2;
-                    } else if (jumpFactorWrite == 27) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +14) {
                         document.getElementById("dronesOffCommand").value = data2;
-                    } else if (jumpFactorWrite == 28) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +15) {
                         document.getElementById("dronesOffChannel").value = data2;
-                    } else if (jumpFactorWrite == 29) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +16) {
                         document.getElementById("dronesOffByte2").value = data2;
-                    } else if (jumpFactorWrite == 30) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +17) {
                         document.getElementById("dronesOffByte3").value = data2;
-                    } else if (jumpFactorWrite == 31 && data2 == 0) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +18 && data2 == 0) {
                         document.getElementById("dronesRadio0").checked = true;
-                    } else if (jumpFactorWrite == 31 && data2 == 1) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +18 && data2 == 1) {
                         document.getElementById("dronesRadio1").checked = true;
-                    } else if (jumpFactorWrite == 31 && data2 == 2) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +18 && data2 == 2) {
                         document.getElementById("dronesRadio2").checked = true;
-                    } else if (jumpFactorWrite == 31 && data2 == 3) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +18 && data2 == 3) {
                         document.getElementById("dronesRadio3").checked = true;
-                    } else if (jumpFactorWrite == 32) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +19) {
                         lsb = data2;
-                    } else if (jumpFactorWrite == 33) {
+                    } else if (jumpFactorWrite == MIDI_ED_VARS_START +20) {
                         var x = parseInt((data2 << 7) | lsb); //receive pressure between 100 and 900
                         x = (x - 100) * 24 / 900; //convert to inches of water. 100 is the approximate minimum sensor value.
                         var p = x.toFixed(1); //round to 1 decimal
                         p = Math.min(Math.max(p, 0), 24); //constrain
                         document.getElementById("dronesPressureInput").value = p;
-                    } else if (jumpFactorWrite == 34) {
+                    } else if (jumpFactorWrite == MIDI_LEARNED_PRESS_LSB) {
                         lsb = data2;
 
-                    } else if (jumpFactorWrite == 35) {
+                    } else if (jumpFactorWrite == MIDI_LEARNED_PRESS_MSB) {
                         var x = parseInt((data2 << 7) | lsb); //receive pressure between 100 and 900
                         x = (x - 100) * 24 / 900; //convert to inches of water.  100 is the approximate minimum sensor value.
                         var p = x.toFixed(1); //round to 1 decimal
                         p = Math.min(Math.max(p, 0), 24); //constrain
                         document.getElementById("octavePressureInput").value = p;
-                    } else if (jumpFactorWrite == 43) {
+                    } else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +3) {
                         document.getElementById("checkbox9").checked = data2;
                     } //invert											
-                    else if (jumpFactorWrite == 44) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +4) {
                         document.getElementById("checkbox5").checked = data2; //custom
                         updateCustom();
-                    } else if (jumpFactorWrite == 42) {
+                    } else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +2) {
                         document.getElementById("checkbox3").checked = data2;
                     } //secret										
-                    else if (jumpFactorWrite == 40) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START) {
                         updateSelected();
                         document.getElementById("checkbox4").checked = data2;
                         if (data2 == 0) {
                             document.getElementById("bagBreath0").checked = true;
                         } else { document.getElementById("bagBreath1").checked = true; }
                     } //vented							 			
-                    else if (jumpFactorWrite == 41) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +1) {
                         document.getElementById("checkbox8").checked = data2;
                     } //bagless						 	
-                    else if (jumpFactorWrite == 45) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +5) {
                         document.getElementById("checkbox10").checked = data2;
                     } //velocity	
-                    else if (jumpFactorWrite == 46) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +6) {
                         document.getElementById("checkbox11").checked = (data2 & 0x1);
                         document.getElementById("checkbox13").checked = (data2 & 0x2);
                     } //aftertouch	
-                    else if (jumpFactorWrite == 47) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +7) {
                         document.getElementById("checkbox12").checked = data2;
                     } //force max velocity
 
-                    else if (jumpFactorWrite == 48) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +8) {
                         document.getElementById("checkbox14").checked = data2;
                     } //immediate pitchbend
 
-                    else if (jumpFactorWrite == 49) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +9) {
                         document.getElementById("checkbox15").checked = data2;
                     } //legato
 
-                    else if (jumpFactorWrite == 50) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +10) {
                         document.getElementById("checkbox16").checked = data2;
                     } //override expression pressure range
 
-                    else if (jumpFactorWrite == 51) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +11) {
                         document.getElementById("checkbox17").checked = data2;
                     } //both thumb and overblow
 
-                    else if (jumpFactorWrite == 52) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +12) {
                         document.getElementById("checkbox18").checked = data2;
                         updateCustom();
                     } //R4 flattens
 
                     /*
-                    else if (jumpFactorWrite == 53) {
+                    else if (jumpFactorWrite == MIDI_SWITCHES_VARS_START +13) {
                         document.getElementById("checkbox19").checked = data2;
                         updateCustom();
                     } //R4 Invert
                     */
 
-                    else if (jumpFactorWrite == 61) {
+                    else if (jumpFactorWrite == MIDI_BEND_RANGE) {
                         document.getElementById("midiBendRange").value = data2;
                     }
-                    else if (jumpFactorWrite == 62) {
+                    else if (jumpFactorWrite == MIDI_MIDI_CHANNEL) {
                         document.getElementById("noteChannel").value = data2;
                     }
-                    else if (jumpFactorWrite == 70) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START) {
                         inputSliderMin[1] = data2;
                         slider.noUiSlider.set([data2, null]);
                     }
-                    else if (jumpFactorWrite == 71) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +1) {
                         inputSliderMax[1] = data2;
                         slider.noUiSlider.set([null, data2]);
                     }
-                    else if (jumpFactorWrite == 72) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +2) {
                         outputSliderMin[1] = data2;
                         slider2.noUiSlider.set([data2, null]);
                     }
-                    else if (jumpFactorWrite == 73) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +3) {
                         outputSliderMax[1] = data2;
                         slider2.noUiSlider.set([null, data2]);
                     }
-                    else if (jumpFactorWrite == 74) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +4) {
                         inputSliderMin[2] = data2;
                         slider.noUiSlider.set([data2, null]);
                     }
-                    else if (jumpFactorWrite == 75) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +5) {
                         inputSliderMax[2] = data2;
                         slider.noUiSlider.set([null, data2]);
                     }
-                    else if (jumpFactorWrite == 76) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +6) {
                         outputSliderMin[2] = data2;
                         slider2.noUiSlider.set([data2, null]);
                     }
-                    else if (jumpFactorWrite == 77) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +7) {
                         outputSliderMax[2] = data2;
                         slider2.noUiSlider.set([null, data2]);
                     }
-                    else if (jumpFactorWrite == 78) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +8) {
                         inputSliderMin[3] = data2;
                         slider.noUiSlider.set([data2, null]);
                     }
-                    else if (jumpFactorWrite == 79) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +9) {
                         inputSliderMax[3] = data2;
                         slider.noUiSlider.set([null, data2]);
                     }
-                    else if (jumpFactorWrite == 80) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +10) {
                         outputSliderMin[3] = data2;
                         slider2.noUiSlider.set([data2, null]);
                     }
-                    else if (jumpFactorWrite == 81) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +11) {
                         outputSliderMax[3] = data2;
                         slider2.noUiSlider.set([null, data2]);
                     }
-                    else if (jumpFactorWrite == 82) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +12) {
                         curve[1] = data2;
                     }
-                    else if (jumpFactorWrite == 83) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +13) {
                         curve[2] = data2;
                     }
-                    else if (jumpFactorWrite == 84) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +14) {
                         curve[3] = data2;
                     }
-                    else if (jumpFactorWrite == 85) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +15) {
                         slider3.noUiSlider.set([data2, null]);
                     }
-                    else if (jumpFactorWrite == 86) {
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +16) {
                         slider3.noUiSlider.set([null, data2]);
                     }
-                    else if (jumpFactorWrite == 87) {
+                    /* MrMep: Careful: this might break backward compatibility: jumpFactor 87 was CUSTOM_FINGERING_1 in WARBL1 */
+                    else if (jumpFactorWrite == MIDI_ED_VARS2_START +17) {
 						// slideLimit
 						document.getElementById("slidelimit").value = data2 ;
 	                    var output = document.getElementById("demo18");
 	                    depth.dispatchEvent(new Event('input'));
 	                    output.innerHTML = data2;
 					}
-
-                    else if (jumpFactorWrite > 86 && jumpFactorWrite < 98) { //custom fingering chart inputs
+                    /* MrMep: 87 is not catched by the following */
+                    else if (jumpFactorWrite >= MIDI_CC_104_VALUE_87 && jumpFactorWrite <= MIDI_ED_VARS2_END) { //custom fingering chart inputs -WARBL1
                         document.getElementById("fingeringInput" + (jumpFactorWrite - 86)).value = data2;
                     }
 
-                    else if (jumpFactorWrite >= 200) { //receiving WARBL2 IMU settings
+                    else if (jumpFactorWrite >=  MIDI_CC_109_OFFSET) { //receiving WARBL2 IMU settings
 
-
-                        if (jumpFactorWrite == 200) {
+                        if (jumpFactorWrite == MIDI_CC_109_OFFSET) {
                             document.getElementById("checkbox20").checked = data2;
                         }
-                        else if (jumpFactorWrite == 201) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +1) {
                             document.getElementById("checkbox21").checked = data2;
                         }
-                        else if (jumpFactorWrite == 202) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +2) {
                             document.getElementById("checkbox22").checked = data2;
                         }
-                        else if (jumpFactorWrite == 203) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +3) {
                             center[1] = data2;
                         }
-                        else if (jumpFactorWrite == 204) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +4) {
                             center[3] = data2;
                         }
-                        else if (jumpFactorWrite == 205) { //input (-90 to 90)
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +5) { //input (-90 to 90)
                             inputSliderMin[4] = (data2 * 5) - 90;
 							//console.log("roll in min= "); 
 							//console.log(data2); 
                         }
-                        else if (jumpFactorWrite == 206) { //input (-90 to 90)
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +6) { //input (-90 to 90)
                             inputSliderMax[4] = (data2 * 5) - 90;
 							//console.log("roll in max= "); 
 							//console.log(data2); 
                         }
-                        else if (jumpFactorWrite == 207) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +7) {
                             outputSliderMin[4] = data2;
 							//console.log("roll out min= "); 
 							//console.log(data2); 
                         }
-                        else if (jumpFactorWrite == 208) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +8) {
                             outputSliderMax[4] = data2;
 							//console.log("roll out max = "); 
 							//console.log(data2);
                         }
-                        else if (jumpFactorWrite == 209) { //input (-90 to 90)
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +9) { //input (-90 to 90)
                             inputSliderMin[5] = (data2 * 5) - 90;
                         }
-                        else if (jumpFactorWrite == 210) { //input (-90 to 90)
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +10) { //input (-90 to 90)
                             inputSliderMax[5] = (data2 * 5) - 90;
                         }
-                        else if (jumpFactorWrite == 211) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +11) {
                             outputSliderMin[5] = data2;
                         }
-                        else if (jumpFactorWrite == 212) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +12) {
                             outputSliderMax[5] = data2;
                         }
-                        else if (jumpFactorWrite == 213) { //Yaw input min (0-180)
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +13) { //Yaw input min (0-180)
                             inputSliderMin[6] = (data2 * 5) - 90;
                         }
-                        else if (jumpFactorWrite == 214) { //Yaw input max (0-180)
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +14) { //Yaw input max (0-180)
                             inputSliderMax[6] = (data2 * 5) - 90;
                         }
-                        else if (jumpFactorWrite == 215) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +15) {
                             outputSliderMin[6] = data2;
                         }
-                        else if (jumpFactorWrite == 216) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +16) {
                             outputSliderMax[6] = data2;
                         }
-                        else if (jumpFactorWrite == 217) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +17) {
                             IMUchannel[0] = data2;
                         }
-                        else if (jumpFactorWrite == 218) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +18) {
                             IMUchannel[1] = data2;
                         }
-                        else if (jumpFactorWrite == 219) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +19) {
                             IMUchannel[2] = data2;
                         }
-                        else if (jumpFactorWrite == 220) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +20) {
                             IMUnumber[0] = data2;
                         }
-                        else if (jumpFactorWrite == 221) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +21) {
                             IMUnumber[1] = data2;
                         }
-                        else if (jumpFactorWrite == 222) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +22) {
                             IMUnumber[2] = data2;
                         }
-                        else if (jumpFactorWrite == 223) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +23) {
                             document.getElementById("checkbox25").checked = data2;
                         }
-                        else if (jumpFactorWrite == 224) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +24) {
                             document.getElementById("checkbox24").checked = data2;
                         }
-                        else if (jumpFactorWrite == 225) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +25) {
                             document.getElementById("autoCenterYawInterval").value = data2;
                             var output = document.getElementById("demo16");
                             autoCenterYawInterval.dispatchEvent(new Event('input'));
                             output.innerHTML = data2 / 4;
                         }
-						else if (jumpFactorWrite == 226) {
+						else if (jumpFactorWrite == MIDI_CC_109_OFFSET +26) {
                             document.getElementById("checkbox27").checked = data2;
                         }
-                        else if (jumpFactorWrite == 227) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +27) {
                             document.getElementById("shakeDepth").value = data2;
                             var output = document.getElementById("demo15");
                             shakeDepth.dispatchEvent(new Event('input'));
                             output.innerHTML = data2;
                         }		
-						else if (jumpFactorWrite == 228) { //input (-90 to 90)
+						else if (jumpFactorWrite == MIDI_CC_109_OFFSET +28) { //input (-90 to 90)
 							  slider6.noUiSlider.set([(data2 * 5) - 90, null]);
                         }
-						else if (jumpFactorWrite == 229) { //input (-90 to 90)
+						else if (jumpFactorWrite == MIDI_CC_109_OFFSET +29) { //input (-90 to 90)
 							  slider6.noUiSlider.set([null, (data2 * 5) - 90]);
                         }
-						else if (jumpFactorWrite == 230) {
+						else if (jumpFactorWrite == MIDI_CC_109_OFFSET +30) {
                             document.getElementById("pitchRegisterNumber").value = data2;
                             var output = document.getElementById("demo17");
                             pitchRegisterNumber.dispatchEvent(new Event('input'));
                             output.innerHTML = data2;
                         }
-                        else if (jumpFactorWrite == 231) {
+                        else if (jumpFactorWrite == MIDI_CC_109_OFFSET +31) {
                             document.getElementById("shakeVibModeCommand").value = data2;
                         }
 						
 						//End of WARBL2 IMU settings
 						
-						else if (jumpFactorWrite == 327) { // Receive button/gesture action
+						else if (jumpFactorWrite == MIDI_CC_109_OFFSET + MIDI_CC_109_VALUE_127) { // Receive button/gesture action
 						var gesture = document.getElementById("gestureLabel" + (data2));
 						gesture.style.color = "#f7c839";
 						gesture.style.scale="1.1"					
@@ -1352,16 +1373,14 @@ function WARBL_Receive(event) {
 
 
 
-
-                else if (data1 == 109 && data2 < 23) { //Indicates WARBL2 IMU setting will be received on CC105
-                    jumpFactorWrite = data2 + 200;
+                /* MrMep: Should this be 33 instead of 23? */
+                // else if (data1 == MIDI_CC_109 && data2 < 23) { //Indicates WARBL2 IMU setting will be received on CC105
+                else if (data1 == MIDI_CC_109 && data2 <= MIDI_IMU_SETTINGS_END) { //Indicates WARBL2 IMU setting will be received on CC105
+                    jumpFactorWrite = data2 + MIDI_CC_109_OFFSET;
                 }
 
 
-                else if (data1 == 110) { //receiving firmware version from WARBL
-
-
-
+                else if (data1 == MIDI_CC_110) { //receiving firmware version from WARBL
 
                     version = data2;
 
@@ -1669,15 +1688,15 @@ function WARBL_Receive(event) {
 
 
 
-                } else if (data1 == 111) {
+                } else if (data1 == MIDI_CC_111) {
                     document.getElementById("keySelect0").value = data2;
-                } else if (data1 == 112) {
+                } else if (data1 == MIDI_CC_112) {
                     document.getElementById("keySelect1").value = data2;
-                } else if (data1 == 113) {
+                } else if (data1 == MIDI_CC_113) {
                     document.getElementById("keySelect2").value = data2;
-                } else if (data1 == 116) {
+                } else if (data1 == MIDI_CC_116) {
                     lsb = data2;
-                } else if (data1 == 118) {
+                } else if (data1 == MIDI_CC_118) {
                     var x = parseInt((data2 << 7) | lsb); //receive pressure between 100 and 900
                     x = (x - 100) * 24 / 900; //convert to inches of water.  105 is the approximate minimum sensor value.
                     p = Math.min(Math.max(p, 0), 24); //constrain
@@ -1698,13 +1717,13 @@ function WARBL_Receive(event) {
 
                 for (var i = 0; i < numberOfGestures; i++) {
                     if (buttonRowWrite == i) {
-                        if (data1 == 106 && data2 < 16) {
+                        if (data1 == MIDI_CC_106 && data2 <= MIDI_ACTION_MIDI_CHANNEL_END) {
                             document.getElementById("channel" + (buttonRowWrite)).value = data2;
                         }
-                        if (data1 == 107) {
+                        if (data1 == MIDI_CC_107) {
                             document.getElementById("byte2_" + (buttonRowWrite)).value = data2;
                         }
-                        if (data1 == 108) {
+                        if (data1 == MIDI_CC_108) {
                             document.getElementById("byte3_" + (buttonRowWrite)).value = data2;
                         }
                     }
@@ -1713,24 +1732,24 @@ function WARBL_Receive(event) {
 
 
 
-                if (data1 == 106 && data2 > 15) {
+                if (data1 == MIDI_CC_106 && data2 > MIDI_ACTION_MIDI_CHANNEL_END) {
 
-                    if (data2 > 19 && data2 < 29) {
-                        document.getElementById("vibratoCheckbox" + (data2 - 20)).checked = false;
+                    if (data2 >= MIDI_ENA_VIBRATO_HOLES_START && data2 <= MIDI_ENA_VIBRATO_HOLES_END) {
+                        document.getElementById("vibratoCheckbox" + (data2 - MIDI_ENA_VIBRATO_HOLES_START)).checked = false;
                     }
 
-                    if (data2 > 29 && data2 < 39) {
-                        document.getElementById("vibratoCheckbox" + (data2 - 30)).checked = true;
+                    if (data2 >= MIDI_DIS_VIBRATO_HOLES_START && data2 <= MIDI_DIS_VIBRATO_HOLES_END) {
+                        document.getElementById("vibratoCheckbox" + (data2 - MIDI_DIS_VIBRATO_HOLES_START)).checked = true;
                     }
 
-                    if (data2 == 39) {
+                    if (data2 == MIDI_STARTUP_CALIB) {
                         document.getElementById("calibrateradio0").checked = true;
                     }
-                    if (data2 == 40) {
+                    if (data2 == MIDI_USE_LEARNED_CALIB) {
                         document.getElementById("calibrateradio1").checked = true;
                     }
 
-                    if (data2 == 53) { //add an option for the uilleann regulators fingering pattern if a message is received indicating that it is supported.
+                    if (data2 == MIDI_CC_106_VALUE_53) { //add an option for the uilleann regulators fingering pattern if a message is received indicating that it is supported.
 
                         for (i = 0; i < document.getElementById("fingeringSelect0").length; ++i) {
                             if (document.getElementById("fingeringSelect0").options[i].value == "9") {
@@ -1761,19 +1780,19 @@ function WARBL_Receive(event) {
                     }
 
 
-                    if (data2 > 54 && data2 < 75) {
-                        WARBL2SettingsReceive = data2 - 55;
+                    if (data2 >= MIDI_WARBL2_SETTINGS_START && data2 <= MIDI_WARBL2_SETTINGS_END) {
+                        WARBL2SettingsReceive = data2 - MIDI_WARBL2_SETTINGS_START;
                     }
 
 
-                    if (data2 > 99 && version > 3.9) {
+                    if (data2 >= MIDI_BUTTON_ACTIONS_START && version > 3.9) {
 						
 						//console.log(buttonRowWrite); 
 
                         for (var j = 0; j < numberOfGestures; j++) { //update button configuration	
                             if (buttonRowWrite == j) {
                                 for (var k = 0; k < 27; k++) {
-                                    if (data2 == 100 + k) {
+                                    if (data2 == MIDI_BUTTON_ACTIONS_START + k) {
                                         document.getElementById("row" + (buttonRowWrite)).value = k;
                                     }
                                 }
@@ -1787,7 +1806,7 @@ function WARBL_Receive(event) {
 
 
 
-                if (data1 == 119) {
+                if (data1 == MIDI_CC_119) {
                     if (WARBL2SettingsReceive == 0) {
                         document.getElementById("WARBL2Radio" + data2).checked = true;
                     }
@@ -1910,7 +1929,8 @@ function turnOffFault(){
 
 
 
-
+// MrMep: I don't think this applies to WARBL2
+// I'm not modifying it
 function sendCustomFingeringFill() {
 
     modalclose(22);
@@ -1920,8 +1940,9 @@ function sendCustomFingeringFill() {
 
         document.getElementById("fingeringInput" + i).value = customFingeringFills[selection][i - 1];
         var x = document.getElementById("fingeringInput" + i).value;
-        sendToWARBL(104, 86 + i);
-        sendToWARBL(105, x);
+
+        sendToWARBL(MIDI_CC_104, 86 + i);
+        sendToWARBL(MIDI_CC_105, x);
 
     }
     document.getElementById("customFingeringFill").value = "12";
@@ -1964,9 +1985,9 @@ function sendWARBL2CustomFingeringFill() {
         }
     }
     //console.log(selection + 100);
-    sendToWARBL(109, (selection + 100));
+    sendToWARBL(MIDI_CC_109, (selection + MIDI_CUSTOM_CHARTS_START));
     for (var k = 0; k < 256; k++) {
-        sendToWARBL(105, lines[k]);
+        sendToWARBL(MIDI_CC_105, lines[k]);
     }
 
 
@@ -1977,7 +1998,8 @@ function sendWARBL2CustomFingeringFill() {
 
 
 
-
+// MrMep: I don't think this applies to WARBL2
+// I'm not modifying it
 function fingeringInput(input, selection) { 	//send the custom fingering input entry
     var x = document.getElementById("fingeringInput" + input).value;
     /*
@@ -1988,8 +2010,8 @@ function fingeringInput(input, selection) { 	//send the custom fingering input e
     else{
         */
 
-    sendToWARBL(104, 86 + input);
-    sendToWARBL(105, x);
+    sendToWARBL(MIDI_CC_104, 86 + input);
+    sendToWARBL(MIDI_CC_105, x);
     //}
 }
 
@@ -2043,8 +2065,8 @@ function sendFingeringSelect(row, selection) {
 	else {key = 0;} // For WARBL2 always revert key (transpose) to 0 when a new fingerin chart is selected
 	document.getElementById("keySelect" + row).value = key; //set key menu
     //send the fingering pattern
-    sendToWARBL(102, 30 + row);
-    sendToWARBL(102, 33 + selection);
+    sendToWARBL(MIDI_CC_102, MIDI_FINGERING_PATTERN_MODE_START + row);
+    sendToWARBL(MIDI_CC_102, MIDI_FINGERING_PATTERN_START + selection);
 
     sendKey(row, key);
 }
@@ -2057,7 +2079,7 @@ function defaultInstrument() { //tell WARBL to set the current instrument as the
 
     defaultInstr = instrument;
     handleDefault();
-    sendToWARBL(102, 85);
+    sendToWARBL(MIDI_CC_102, MIDI_DEFAULT_MODE_START);
 
 }
 
@@ -2109,7 +2131,7 @@ function sendKey(row, selection) {
     row = parseFloat(row);
     updateCells();
     blink(1);
-    sendToWARBL(111 + row, selection);
+    sendToWARBL(MIDI_CC_111 + row, selection);
 }
 
 function sendFingeringRadio(tab) { //change instruments, showing the correct tab for each instrument.
@@ -2134,7 +2156,7 @@ function sendFingeringRadio(tab) { //change instruments, showing the correct tab
         document.getElementById("key0").style.display = "block";
         document.getElementById("key1").style.display = "none";
         document.getElementById("key2").style.display = "none";
-        sendToWARBL(102, 60);
+        sendToWARBL(MIDI_CC_102, MIDI_CURRENT_MODE_START);
     } else if (tab == 1) {
         document.getElementById("instrument0").style.display = "none";
         document.getElementById("instrument1").style.display = "block";
@@ -2144,7 +2166,7 @@ function sendFingeringRadio(tab) { //change instruments, showing the correct tab
         document.getElementById("key1").style.display = "block";
         document.getElementById("key2").style.display = "none";
         blink(2);
-        sendToWARBL(102, 61);
+        sendToWARBL(MIDI_CC_102, MIDI_CURRENT_MODE_START +1);
     } else if (tab == 2) {
         document.getElementById("instrument0").style.display = "none";
         document.getElementById("instrument1").style.display = "none";
@@ -2154,7 +2176,7 @@ function sendFingeringRadio(tab) { //change instruments, showing the correct tab
         document.getElementById("key1").style.display = "none";
         document.getElementById("key2").style.display = "block";
         blink(3);
-        sendToWARBL(102, 62);
+        sendToWARBL(MIDI_CC_102, MIDI_CURRENT_MODE_START +2);
     }
     updateCells();
     updateCustom();
@@ -2178,56 +2200,56 @@ function sendSenseDistance(selection) {
     blink(1);
     selection = parseFloat(selection);
     x = 0 - parseFloat(selection);
-    sendToWARBL(103, x);
+    sendToWARBL(MIDI_CC_103, x);
 }
 
 
 function sendDepth(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(117, selection);
+    sendToWARBL(MIDI_CC_117, selection);
 }
 
 function sendSlideLimit(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(104, 87);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SLIDE_LIMIT_MAX);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendShakeDepth(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(109, 27);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_Y_PITCHBEND_DEPTH);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendShakeVibModeOnCommand(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(109, 31);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_Y_PITCHBEND_MODE);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendAutoCenterYawInterval(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(109, 25);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_AUTOCENTER_YAW_INTERVAL);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendpitchRegisterNumber(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(109, 30);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_PITCH_REGISTER_NUMBER);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendExpressionDepth(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(104, 14);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_EXPRESSION_DEPTH);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendCurveRadio(selection) {
@@ -2235,12 +2257,12 @@ function sendCurveRadio(selection) {
     selection = parseFloat(selection);
     curve[mapSelection] = selection;
     if (mapSelection == 0) {
-        sendToWARBL(104, 16);
+        sendToWARBL(MIDI_CC_104, MIDI_CURVE);
     }
     else {
-        sendToWARBL(104, 81 + mapSelection);
+        sendToWARBL(MIDI_CC_104, MIDI_VELOCITY_CURVE + mapSelection - 1);
     }
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendPressureChannel(selection) {
@@ -2250,16 +2272,16 @@ function sendPressureChannel(selection) {
         alert("Value must be 1-16.");
         document.getElementById("pressureChannel").value = null;
     } else {
-        sendToWARBL(104, 17);
-        sendToWARBL(105, x);
+        sendToWARBL(MIDI_CC_104, MIDI_PRESSURE_CHANNEL);
+        sendToWARBL(MIDI_CC_105, x);
     }
 }
 
 function sendPressureCC(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(104, 18);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_PRESSURE_CC);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendBendRange(selection) {
@@ -2269,8 +2291,8 @@ function sendBendRange(selection) {
         alert("Value must be 1-96.");
         document.getElementById("midiBendRange").value = null;
     } else {
-        sendToWARBL(104, 61);
-        sendToWARBL(105, x);
+        sendToWARBL(MIDI_CC_104, MIDI_BEND_RANGE);
+        sendToWARBL(MIDI_CC_105, x);
     }
 }
 
@@ -2281,8 +2303,8 @@ function sendNoteChannel(selection) {
         alert("Value must be 1-16.");
         document.getElementById("noteChannel").value = null;
     } else {
-        sendToWARBL(104, 62);
-        sendToWARBL(105, x);
+        sendToWARBL(MIDI_CC_104, MIDI_MIDI_CHANNEL);
+        sendToWARBL(MIDI_CC_105, x);
     }
 }
 
@@ -2293,18 +2315,18 @@ slider.noUiSlider.on('change', function (values) {
     if (mapSelection == 0) {
         inputSliderMin[0] = parseInt(values[0]);
         inputSliderMax[0] = parseInt(values[1]);
-        sendToWARBL(104, 19);
-        sendToWARBL(105, parseInt(values[0]));
-        sendToWARBL(104, 20);
-        sendToWARBL(105, parseInt(values[1]));
+        sendToWARBL(MIDI_CC_104, MIDI_INPUT_PRESSURE_MIN);
+        sendToWARBL(MIDI_CC_105, parseInt(values[0]));
+        sendToWARBL(MIDI_CC_104, MIDI_INPUT_PRESSURE_MAX);
+        sendToWARBL(MIDI_CC_105, parseInt(values[1]));
     }
     else {
         inputSliderMin[mapSelection] = parseInt(values[0]);
         inputSliderMax[mapSelection] = parseInt(values[1]);
-        sendToWARBL(104, 70 + ((mapSelection - 1) * 4));
-        sendToWARBL(105, parseInt(values[0]));
-        sendToWARBL(104, 71 + ((mapSelection - 1) * 4));
-        sendToWARBL(105, parseInt(values[1]));
+        sendToWARBL(MIDI_CC_104, MIDI_ED_VARS2_START + ((mapSelection - 1) * 4));
+        sendToWARBL(MIDI_CC_105, parseInt(values[0]));
+        sendToWARBL(MIDI_CC_104, MIDI_ED_VARS2_START + 1 + ((mapSelection - 1) * 4));
+        sendToWARBL(MIDI_CC_105, parseInt(values[1]));
     }
 });
 
@@ -2314,28 +2336,28 @@ slider2.noUiSlider.on('change', function (values) {
     if (mapSelection == 0) {
         outputSliderMin[0] = parseInt(values[0]);
         outputSliderMax[0] = parseInt(values[1]);
-        sendToWARBL(104, 21);
-        sendToWARBL(105, parseInt(values[0]));
-        sendToWARBL(104, 22);
-        sendToWARBL(105, parseInt(values[1]));
+        sendToWARBL(MIDI_CC_104, MIDI_OUTPUT_PRESSURE_MIN);
+        sendToWARBL(MIDI_CC_105, parseInt(values[0]));
+        sendToWARBL(MIDI_CC_104, MIDI_OUTPUT_PRESSURE_MAX);
+        sendToWARBL(MIDI_CC_105, parseInt(values[1]));
     }
     else {
         outputSliderMin[mapSelection] = parseInt(values[0]);
         outputSliderMax[mapSelection] = parseInt(values[1]);
-        sendToWARBL(104, 72 + ((mapSelection - 1) * 4));
-        sendToWARBL(105, parseInt(values[0]));
-        sendToWARBL(104, 73 + ((mapSelection - 1) * 4));
-        sendToWARBL(105, parseInt(values[1]));
+        sendToWARBL(MIDI_CC_104, MIDI_ED_VARS2_START +2 + ((mapSelection - 1) * 4));
+        sendToWARBL(MIDI_CC_105, parseInt(values[0]));
+        sendToWARBL(MIDI_CC_104, MIDI_ED_VARS2_START +3 + ((mapSelection - 1) * 4));
+        sendToWARBL(MIDI_CC_105, parseInt(values[1]));
     }
 });
 
 //expression override slider
 slider3.noUiSlider.on('change', function (values) {
     blink(1);
-    sendToWARBL(104, 85);
-    sendToWARBL(105, parseInt(values[0]));
-    sendToWARBL(104, 86);
-    sendToWARBL(105, parseInt(values[1]));
+    sendToWARBL(MIDI_CC_104, MIDI_EXPRESSION_MIN);
+    sendToWARBL(MIDI_CC_105, parseInt(values[0]));
+    sendToWARBL(MIDI_CC_104, MIDI_EXPRESSION_MAX);
+    sendToWARBL(MIDI_CC_105, parseInt(values[1]));
 });
 
 
@@ -2370,20 +2392,20 @@ slider5.noUiSlider.on('change', function (values, handle) {
 	
 	//console.log(inputSliderMin[IMUmapSelection + 3]); 
 
-    sendToWARBL(109, ((IMUmapSelection) * 4 + 1));
+    sendToWARBL(MIDI_CC_109, ((IMUmapSelection) * 4 + 1));
     if (IMUmapSelection == 3) {
-        sendToWARBL(105, (parseInt(handles[0]) + 90) / 5); //convert to 1-36 steps to send
+        sendToWARBL(MIDI_CC_105, (parseInt(handles[0]) + 90) / 5); //convert to 1-36 steps to send
     }
     else {
-        sendToWARBL(105, (parseInt(handles[0]) + 90) / 5);
+        sendToWARBL(MIDI_CC_105, (parseInt(handles[0]) + 90) / 5);
     }
-    sendToWARBL(109, ((IMUmapSelection) * 4) + 2);
+    sendToWARBL(MIDI_CC_109, ((IMUmapSelection) * 4) + 2);
 
     if (IMUmapSelection == 3) {
-        sendToWARBL(105, (parseInt(handles[1]) + 90) / 5);
+        sendToWARBL(MIDI_CC_105, (parseInt(handles[1]) + 90) / 5);
     }
     else {
-        sendToWARBL(105, (parseInt(handles[1]) + 90) / 5);
+        sendToWARBL(MIDI_CC_105, (parseInt(handles[1]) + 90) / 5);
     }
 
 });
@@ -2395,10 +2417,10 @@ slider4.noUiSlider.on('change', function (values, handle) {
     outputSliderMin[IMUmapSelection + 3] = parseInt(values[0]);
     outputSliderMax[IMUmapSelection + 3] = parseInt(values[1]);
 
-    sendToWARBL(109, ((IMUmapSelection) * 4 + 3));
-    sendToWARBL(105, parseInt(values[0]));
-    sendToWARBL(109, ((IMUmapSelection) * 4 + 4));
-    sendToWARBL(105, parseInt(values[1]));
+    sendToWARBL(MIDI_CC_109, ((IMUmapSelection) * 4 + 3));
+    sendToWARBL(MIDI_CC_105, parseInt(values[0]));
+    sendToWARBL(MIDI_CC_109, ((IMUmapSelection) * 4 + 4));
+    sendToWARBL(MIDI_CC_105, parseInt(values[1]));
 
 
 });
@@ -2509,10 +2531,10 @@ slider6.noUiSlider.on('change', function (values, handle) {
 	 var handles = slider6.noUiSlider.get();
     inputSliderMin[IMUmapSelection + 3] = parseInt(handles[0]);
     inputSliderMax[IMUmapSelection + 3] = parseInt(handles[1]);
-    sendToWARBL(109, 28);
-    sendToWARBL(105, (parseInt(handles[0]) + 90) / 5); //convert to 1-36 steps to send
-    sendToWARBL(109, 29);
-    sendToWARBL(105, (parseInt(handles[1]) + 90) / 5); //convert to 1-36 steps to send
+    sendToWARBL(MIDI_CC_109, MIDI_PITCH_REGISTER_INPUT_MIN);
+    sendToWARBL(MIDI_CC_105, (parseInt(handles[0]) + 90) / 5); //convert to 1-36 steps to send
+    sendToWARBL(MIDI_CC_109, MIDI_PITCH_REGISTER_INPUT_MAX);
+    sendToWARBL(MIDI_CC_105, (parseInt(handles[1]) + 90) / 5); //convert to 1-36 steps to send
 });
 
 
@@ -2521,51 +2543,51 @@ slider6.noUiSlider.on('change', function (values, handle) {
 function sendRoll(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(109, 0);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_SEND_ROLL);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendPitch(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(109, 1);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_SEND_PITCH);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendYaw(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(109, 2);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_SEND_YAW);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendShake(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(109, 24);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_Y_SHAKE_PITCHBEND);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendAutoCenterYaw(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(109, 23);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_AUTOCENTER_YAW);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendPitchRegister(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(109, 26);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, MIDI_PITCH_REGISTER);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 
 function sendDronesOnCommand(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(104, 23);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_DRONES_ON_COMMAND);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendDronesOnChannel(selection) {
@@ -2575,8 +2597,8 @@ function sendDronesOnChannel(selection) {
         document.getElementById("dronesOnChannel").value = null;
     } else {
         blink(1);
-        sendToWARBL(104, 24);
-        sendToWARBL(105, x);
+        sendToWARBL(MIDI_CC_104, MIDI_DRONES_ON_CHANNEL);
+        sendToWARBL(MIDI_CC_105, x);
     }
 }
 
@@ -2587,8 +2609,8 @@ function sendDronesOnByte2(selection) {
         document.getElementById("dronesOnByte2").value = null;
     } else {
         blink(1);
-        sendToWARBL(104, 25);
-        sendToWARBL(105, x);
+        sendToWARBL(MIDI_CC_104, MIDI_DRONES_ON_BYTE2);
+        sendToWARBL(MIDI_CC_105, x);
     }
 }
 
@@ -2599,16 +2621,16 @@ function sendDronesOnByte3(selection) {
         document.getElementById("dronesOnByte3").value = null;
     } else {
         blink(1);
-        sendToWARBL(104, 26);
-        sendToWARBL(105, x);
+        sendToWARBL(MIDI_CC_104, MIDI_DRONES_ON_BYTE3);
+        sendToWARBL(MIDI_CC_105, x);
     }
 }
 
 function sendDronesOffCommand(selection) {
     blink(1);
     var y = parseFloat(selection);
-    sendToWARBL(104, 27);
-    sendToWARBL(105, y);
+    sendToWARBL(MIDI_CC_104, MIDI_DRONES_OFF_COMMAND);
+    sendToWARBL(MIDI_CC_105, y);
 }
 
 function sendDronesOffChannel(selection) {
@@ -2618,8 +2640,8 @@ function sendDronesOffChannel(selection) {
         document.getElementById("dronesOffChannel").value = null;
     } else {
         blink(1);
-        sendToWARBL(104, 28);
-        sendToWARBL(105, x);
+        sendToWARBL(MIDI_CC_104, MIDI_DRONES_OFF_CHANNEL);
+        sendToWARBL(MIDI_CC_105, x);
     }
 }
 
@@ -2630,8 +2652,8 @@ function sendDronesOffByte2(selection) {
         document.getElementById("dronesOffByte2").value = null;
     } else {
         blink(1);
-        sendToWARBL(104, 29);
-        sendToWARBL(105, x);
+        sendToWARBL(MIDI_CC_104, MIDI_DRONES_OFF_BYTE2);
+        sendToWARBL(MIDI_CC_105, x);
     }
 }
 
@@ -2642,23 +2664,23 @@ function sendDronesOffByte3(selection) {
         document.getElementById("dronesOffByte3").value = null;
     } else {
         blink(1);
-        sendToWARBL(104, 30);
-        sendToWARBL(105, x);
+        sendToWARBL(MIDI_CC_104, MIDI_DRONES_OFF_BYTE3);
+        sendToWARBL(MIDI_CC_105, x);
     }
 }
 
 function sendDronesRadio(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(104, 31);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_DRONES_CONTROL_MODE);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function learnDrones() {
     blink(1);
     document.getElementById("dronesPressureInput").style.backgroundColor = "#32CD32";
     setTimeout(blinkDrones, 500);
-    sendToWARBL(106, 43);
+    sendToWARBL(MIDI_CC_106, MIDI_LEARN_DRONES_PRESSURE);
 
 }
 
@@ -2681,10 +2703,10 @@ function sendDronesPressure(selection) {
         blink(1);
         document.getElementById("dronesPressureInput").style.backgroundColor = "#32CD32";
         setTimeout(blinkDrones, 500);
-        sendToWARBL(104, 32);
-        sendToWARBL(105, x & 0x7F);
-        sendToWARBL(104, 33);
-        sendToWARBL(105, x >> 7);
+        sendToWARBL(MIDI_CC_104, MIDI_DRONES_PRESSURE_LOW_BYTE);
+        sendToWARBL(MIDI_CC_105, x & 0x7F);
+        sendToWARBL(MIDI_CC_104, MIDI_DRONES_PRESSURE_HIGH_BYTE);
+        sendToWARBL(MIDI_CC_105, x >> 7);
     }
 }
 
@@ -2698,10 +2720,10 @@ function sendOctavePressure(selection) {
         blink(1);
         document.getElementById("octavePressureInput").style.backgroundColor = "#32CD32";
         setTimeout(blinkOctave, 500);
-        sendToWARBL(104, 34);
-        sendToWARBL(105, x & 0x7F);
-        sendToWARBL(104, 35);
-        sendToWARBL(105, x >> 7);
+        sendToWARBL(MIDI_CC_104, MIDI_LEARNED_PRESS_LSB);
+        sendToWARBL(MIDI_CC_105, x & 0x7F);
+        sendToWARBL(MIDI_CC_104, MIDI_LEARNED_PRESS_MSB);
+        sendToWARBL(MIDI_CC_105, x >> 7);
     }
 
 }
@@ -2710,13 +2732,13 @@ function learn() {
     blink(1);
     document.getElementById("octavePressureInput").style.backgroundColor = "#32CD32";
     setTimeout(blinkOctave, 500);
-    sendToWARBL(106, 41);
+    sendToWARBL(MIDI_CC_106, MIDI_LEARN_INITIAL_NOTE_PRESS);
 }
 
 function sendCalibrateRadio(selection) {
     selection = parseFloat(selection);
     blink(1);
-    sendToWARBL(106, 39 + selection);
+    sendToWARBL(MIDI_CC_106, MIDI_STARTUP_CALIB + selection);
 }
 
 function sendPitchbendRadio(selection) {
@@ -2726,12 +2748,12 @@ function sendPitchbendRadio(selection) {
     if (selection > 0) {
         blink(selection + 1);
     }
-    sendToWARBL(102, 70 + selection);
+    sendToWARBL(MIDI_CC_102, MIDI_PB_MODE_START + selection);
 }
 
 function sendVibratoHoles(holeNumber, selection) {
     selection = +selection; //convert true/false to 1/0
-    sendToWARBL(106, (30 - (selection * 10)) + holeNumber);
+    sendToWARBL(MIDI_CC_106, (MIDI_DIS_VIBRATO_HOLES_START - (selection * 10)) + holeNumber);
 }
 
 function updateCustom() { //keep correct settings enabled/disabled with respect to the custom vibrato switch and send pressure as CC switches.
@@ -2746,8 +2768,8 @@ function updateCustom() { //keep correct settings enabled/disabled with respect 
         //document.getElementById("checkbox5").checked = false;
         document.getElementById("checkbox5").disabled = true;
         document.getElementById("switch5").style.cursor = "default";
-        //sendToWARBL(104,44); //if custom is disabled, tell WARBL to turn it off
-        //sendToWARBL(105, 0);
+        //sendToWARBL(MIDI_CC_104,44); //if custom is disabled, tell WARBL to turn it off
+        //sendToWARBL(MIDI_CC_105, 0);
         //blink(1);
     }
     if (document.getElementById("checkbox5").checked == true && document.getElementById("checkbox5").disabled == false) {
@@ -2785,7 +2807,7 @@ function sendBreathmodeRadio(selection) {
     else {
         document.getElementById("checkbox16").disabled = false;
     }
-    sendToWARBL(102, 80 + selection);
+    sendToWARBL(MIDI_CC_102, MIDI_BREATH_MODE_START + selection);
 
 }
 
@@ -3070,28 +3092,28 @@ function sendCenter(selection) {
     center[IMUmapSelection] = selection;
     blink(1);
     if (IMUmapSelection == 1) {
-        sendToWARBL(109, 3);
+        sendToWARBL(MIDI_CC_109, MIDI_SEND_CENTER_ROLL);
     }
     else {
-        sendToWARBL(109, 4);
+        sendToWARBL(MIDI_CC_109, MIDI_SEND_CENTER_YAW);
     }
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendIMUChannel(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
     IMUchannel[IMUmapSelection - 1] = selection;
-    sendToWARBL(109, IMUmapSelection + 16);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, IMUmapSelection - 1 + MIDI_IMU_CHANNEL_START);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendIMUCC(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
     IMUnumber[IMUmapSelection - 1] = selection;
-    sendToWARBL(109, IMUmapSelection + 19);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_109, IMUmapSelection -1 + MIDI_IMU_CC_START);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 
@@ -3208,21 +3230,21 @@ function advancedBagDefaults() {
 function sendJumpFactor(factor, selection) {
     selection = parseFloat(selection);
     blink(1);
-    sendToWARBL(104, factor);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, factor);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 
 function sendRow(rowNum) {
     blink(1);
     updateCells();
-    sendToWARBL(102, 90 + rowNum);
+    sendToWARBL(MIDI_CC_102, MIDI_GESTURE_START + rowNum);
     var y = (100) + parseFloat(document.getElementById("row" + rowNum).value);
     if (version < 4.0) {
-        sendToWARBL(102, y);
+        sendToWARBL(MIDI_CC_102, y);
         sendMIDIrow(rowNum); //this is just to fix an issue with the LED being stuck on with the old WARBL and this Config Tool version.
     }
-    else sendToWARBL(106, y);
+    else sendToWARBL(MIDI_CC_106, y);
     if (rowNum < 3) {
 		sendMomentary(rowNum);
     }
@@ -3231,10 +3253,10 @@ function sendRow(rowNum) {
 function sendMIDIrow(MIDIrowNum) {
     blink(1);
     updateCells();
-    sendToWARBL(102, 90 + MIDIrowNum);
+    sendToWARBL(MIDI_CC_102, MIDI_GESTURE_START + MIDIrowNum);
     var y = (112) + parseFloat(document.getElementById("MIDIrow" + MIDIrowNum).value);
 
-    sendToWARBL(102, y);
+    sendToWARBL(MIDI_CC_102, y);
     //sendChannel(MIDIrowNum);
     //sendByte2(MIDIrowNum);
     //sendByte3(MIDIrowNum);
@@ -3249,24 +3271,24 @@ function sendChannel(rowNum) {
     blink(1);
     MIDIvalueChange();
     var y = parseFloat(document.getElementById("channel" + (rowNum)).value);
-    sendToWARBL(102, 90 + rowNum);
-    sendToWARBL(106, y);
+    sendToWARBL(MIDI_CC_102, MIDI_GESTURE_START + rowNum);
+    sendToWARBL(MIDI_CC_106, y);
 }
 
 function sendByte2(rowNum) {
     blink(1);
     MIDIvalueChange();
-    sendToWARBL(102, 90 + rowNum);
+    sendToWARBL(MIDI_CC_102, MIDI_GESTURE_START + rowNum);
     var y = parseFloat(document.getElementById("byte2_" + (rowNum)).value);
-    sendToWARBL(107, y);
+    sendToWARBL(MIDI_CC_107, y);
 }
 
 function sendByte3(rowNum) {
     blink(1);
     MIDIvalueChange();
-    sendToWARBL(102, 90 + rowNum);
+    sendToWARBL(MIDI_CC_102, MIDI_GESTURE_START + rowNum);
     var y = parseFloat(document.getElementById("byte3_" + (rowNum)).value);
-    sendToWARBL(108, y);
+    sendToWARBL(MIDI_CC_108, y);
 }
 
 function sendMomentary(rowNum) { //send momentary
@@ -3274,12 +3296,12 @@ function sendMomentary(rowNum) { //send momentary
     updateCells();
     var y = document.getElementById("checkbox" + rowNum).checked
 
-    sendToWARBL(102, 90 + rowNum);
+    sendToWARBL(MIDI_CC_102, MIDI_GESTURE_START + rowNum);
     if (y == false) {
-        sendToWARBL(102, 117);
+        sendToWARBL(MIDI_CC_102, MIDI_MOMENTARY_OFF);
     }
     if (y == true) {
-        sendToWARBL(102, 118);
+        sendToWARBL(MIDI_CC_102, MIDI_MOMENTARY_ON);
     }
 }
 
@@ -3288,38 +3310,38 @@ function sendMomentary(rowNum) { //send momentary
 function sendVented(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(104, 40);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START);
+    sendToWARBL(MIDI_CC_105, selection);
     updateSelected();
 }
 
 function sendBagless(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(104, 41);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +1);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendSecret(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(104, 42);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +2);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendInvert(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(104, 43);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +3);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendCustom(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
     updateCustom();
-    sendToWARBL(104, 44);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +4);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 
@@ -3329,23 +3351,23 @@ function sendExpression(selection) {
     //if (selection == 1) {
     //document.getElementById("overrideExpression").disabled = false;
     //} else (document.getElementById("overrideExpression").disabled = true);
-    sendToWARBL(104, 13);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_ED_VARS_START);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendRawPressure(selection) {
     selection = +selection; //convert true/false to 1/0
     updateCustom();
     blink(1);
-    sendToWARBL(104, 15);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SEND_PRESSURE);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendVelocity(selection) {
     selection = +selection; //convert true/false to 1/0
     blink(1);
-    sendToWARBL(104, 45);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +5);
+    sendToWARBL(MIDI_CC_105, selection);
     updateCells();
 }
 
@@ -3353,59 +3375,59 @@ function sendAftertouch(selection, polyselection) {
     selection = +selection; //convert true/false to 1/0
     var val = selection | ((+polyselection) << 1);
     blink(1);
-    sendToWARBL(104, 46);
-    sendToWARBL(105, val);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +6);
+    sendToWARBL(MIDI_CC_105, val);
 }
 
 function sendForceVelocity(selection) {
     selection = +selection;
     blink(1);
-    sendToWARBL(104, 47);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +7);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendHack1(selection) {
     selection = +selection;
     blink(1);
-    sendToWARBL(104, 48);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +8);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendHack2(selection) {
     selection = +selection;
     blink(1);
-    sendToWARBL(104, 49);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +9);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendOverride(selection) {
     selection = +selection;
     blink(1);
-    sendToWARBL(104, 50);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +10);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendBoth(selection) {
     selection = +selection;
     blink(1);
-    sendToWARBL(104, 51);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +11);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 function sendR4flatten(selection) {
     selection = +selection;
     blink(1);
     updateCustom();
-    sendToWARBL(104, 52);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +12);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 
 /* //curently unused--can be used for an additional switch.
 function sendInvertR4(selection) {
     selection = +selection;
     blink(1);
-    sendToWARBL(104, 53);
-    sendToWARBL(105, selection);
+    sendToWARBL(MIDI_CC_104, MIDI_SWITCHES_VARS_START +13);
+    sendToWARBL(MIDI_CC_105, selection);
 }
 */
 
@@ -3415,20 +3437,20 @@ function sendInvertR4(selection) {
 
 function calibrateIMU() {
     blink(1);
-    sendToWARBL(106, 54);
+    sendToWARBL(MIDI_CC_106, MIDI_CALIB_IMU);
 }
 
 function centerYaw() {
     blink(1);
-    sendToWARBL(106, 60);
+    sendToWARBL(MIDI_CC_106, MIDI_CENTER_YAW);
 }
 
 
 function WARBL2Radio(selection) {
     blink(1);
     selection = parseFloat(selection);
-    sendToWARBL(106, 55);
-    sendToWARBL(119, selection);
+    sendToWARBL(MIDI_CC_106, MIDI_WARBL2_SETTINGS_START);
+    sendToWARBL(MIDI_CC_119, selection);
 }
 
 
@@ -3436,15 +3458,15 @@ function sendHost(selection) {
     blink(1);
 
     selection = +selection; //convert true/false to 1/0
-    sendToWARBL(106, 56);
-    sendToWARBL(119, selection);
+    sendToWARBL(MIDI_CC_106, MIDI_WARBL2_SETTINGS_START +1);
+    sendToWARBL(MIDI_CC_119, selection);
 }
 
 function sendPoweroff(selection) {
     selection = parseFloat(selection);
     blink(1);
-    sendToWARBL(106, 57);
-    sendToWARBL(119, selection);
+    sendToWARBL(MIDI_CC_106, MIDI_WARBL2_SETTINGS_START +2);
+    sendToWARBL(MIDI_CC_119, selection);
 }
 
 
@@ -3452,24 +3474,24 @@ function sendPoweroff(selection) {
 function saveAsDefaults() {
     modalclose(2);
     blink(3);
-    sendToWARBL(102, 123);
+    sendToWARBL(MIDI_CC_102, MIDI_SAVE_AS_DEFAULTS_CURRENT);
 }
 
 function saveCalibAsFactoryDefault() { // Only used for "factory calibtration"
 	modalclose(2);
 	blink(3);
-	sendToWARBL(106,45);}
+	sendToWARBL(MIDI_CC_106, MIDI_SAVE_CALIB_AS_FACTORY);}
 
 function saveAsDefaultsForAll() {
     modalclose(3);
     blink(3);
-    sendToWARBL(102, 124);
+    sendToWARBL(MIDI_CC_102, MIDI_SAVE_AS_DEFAULTS_ALL);
 }
 
 function restoreAll() {
     modalclose(4);
     blink(3);
-    sendToWARBL(102, 125);
+    sendToWARBL(MIDI_CC_102, MIDI_RESTORE_FACTORY);
     communicationMode = 0;
     if (version > 1.9 && version < 4.0) { //WARBL will restart, so try to reconnect to it.
         setTimeout(connect, 3000);
@@ -3481,7 +3503,7 @@ function autoCalibrateBell() {
         LEDon();
     }
     setTimeout(LEDoff, 5000);
-    sendToWARBL(106, 42);
+    sendToWARBL(MIDI_CC_106, MIDI_CALIB_BELL_SENSOR);
 }
 
 function autoCalibrate() {
@@ -3489,7 +3511,7 @@ function autoCalibrate() {
         LEDon();
     }
     setTimeout(LEDoff, 10000);
-    sendToWARBL(102, 127);
+    sendToWARBL(MIDI_CC_102, MIDI_START_CALIB);
 }
 
 function frequencyFromNoteNumber(note) {
@@ -4225,7 +4247,7 @@ function importPreset(context) {
 
                 //console.log("refreshing UI");
 
-                sendToWARBL(102, 126);
+                sendToWARBL(MIDI_CC_102, MIDI_ENTER_COMM_MODE);
 
                 // Show the import complete modal
                 document.getElementById("modal14-title").innerHTML = "Preset Import Complete!";
@@ -4339,7 +4361,7 @@ function exportPreset() {
 
     // Tell WARBL to enter communications mode
     // Received bytes will be forwarded to the export message handler instead
-    sendToWARBL(102, 126);
+    sendToWARBL(MIDI_CC_102, MIDI_ENTER_COMM_MODE);
 
 }
 


### PR DESCRIPTION
Second and last PR addressing the definition of constant values #5 
After the first one about EEPROM addresses, this one is about MIDI numerical values.

I understand that it's hundreds of changes, it will require some time to be validated and maybe some changes might look like a futile exercise, but I tried to be consistent and achieve multiple goals:
1. Avoid numerical repetitions in the code (which are frequent cause for errors)
2. Define human readable constants thus making the code easier to understand
3. Making the code easier to maintain and extend.
4. Having an in-code map of used (and available) cc values.
5. Having a consistent naming across firmware and Config tool.

A few times I found an inconsistency between what indicated in the Google Doc and in the code: these are marked in comments beginning with "MrMep": feel free to remove them.

I think I found a small problem, documented  #8 

I hope I haven't made mistakes but, hey, I swear I'm human.


**Brief Changelog**
**Firmware**:

- Added constants defines for MIDI numerical values
- Substituted (almost) all MIDI numerical references with constants defines

**Web Config Too**l:
- Added a new file constants.js
- Modified HTML configure pages to include the new constants.js
- Substituted (almost) all MIDI numerical references with constants defines